### PR TITLE
Add style-guide and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Concordium Documentation
 
+The documentation is structured according to this
+[guide](https://documentation.divio.com/).
+
 It is written in reStructuredText ([Link to the
 basics](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)).
 
@@ -13,61 +16,106 @@ Sphinx supplies a number of useful
 (The sphinx equivalent of LaTeX commands) for stuff like code highlighting,
 remarks, warnings and so on.
 
-Additionally we have enabled the [extension for
+Additionally, we have enabled the [extension for
 todo](https://www.sphinx-doc.org/en/master/usage/extensions/todo.html)
 directives
 ```
 .. todo::
-    Write the todo here
-```
-Which are shown as warnings when building the docs.
 
-To generate some svg graphics, we use the [Graphviz
+   Write a todo here
+```
+Todos are shown as warnings when building the docs.
+
+To generate SVG graphics, we use the [Graphviz
 extension](https://www.sphinx-doc.org/en/master/usage/extensions/graphviz.html).
 
 ## Installation
 
 Install `python3` and the python package manager `pip`.
 
-To install the python dependencies run
+To install the python dependencies run:
 ```
 pip install -r requirements.txt
 ```
 
-Install `graphviz`
+Install `graphviz`:
 
-On Ubuntu
-```
-sudo apt install graphviz
-```
+- MacOS: `brew install graphviz`
+- Ubuntu: `sudo apt install graphviz`
 
 ## Development
 To watch the doc files and automate the build run:
-
-On Linux
 ```
 make dev
 ```
-and navigate to [localhost:8000](http://localhost:8000)
+and navigate to [localhost:8000](http://localhost:8000).
 
-Before commit make sure to run the linter and fix all the errors reported
+Before committing, make sure to run the linter and fix all the errors reported:
 ```
 make lint
 ```
 
-> **Note**: In `make dev` we disable the cache on build as this tend to
-> inconsistencies. If the build time gets to slow, it might be worth enabling
-> again by removing `-E`.
+> **Note**: In `make dev` we disable the cache on build as this tends to cause
+> inconsistencies. If the build time becomes too slow, it might be worth
+> enabling again by removing `-E`.
 
-## Build the docs
-
-On Linux
+## Building the docs
+Run the following command:
 ```
 make html
 ```
 
 
-To check for deadlinks (also done by the CI)
+To check for dead links (also done by the CI), run:
 ```
 make linkcheck
+```
+
+## Style guide
+
+### Headers
+In reST the various levels of headers can be written in multiple ways, but they
+need to be used consistently in our documentation because the theme we use
+interprets them in a specific way, namely: 
+
+``` restructuredtext
+========
+Header 1
+========
+
+Header 2
+========
+
+Header 3
+--------
+
+Header 4
+^^^^^^^^
+
+Header 5
+~~~~~~~~
+```
+
+### Terminal commands
+Code snippets with terminal commands should use `.. code-block:: console`
+and any command should be prefixed with `$` without extra whitespace. 
+A space will be added through CSS and only the command itself will be
+copyable, which improves the user-experience.
+
+Example:
+
+``` restructuredtext
+.. code-block:: console
+   $echo Hello, world!
+   Hello, world!
+```
+
+### Indentation
+In reST it is common to indent block by three spaces because it aligns the
+content of directives to the directive name itself.
+See the example below.
+
+``` restructuredtext
+.. note::
+   This line has three spaces in front and aligns with the note directive. 
 ```


### PR DESCRIPTION
The style guide contains these three parts:

- Headers
- Terminal commands
- Indentation