### PR TITLE
Remove slotNumber, blockHeight, finalizedHeight from the contexts.

### DIFF
--- a/source/smart-contracts/guides/local-simulate.rst
+++ b/source/smart-contracts/guides/local-simulate.rst
@@ -49,9 +49,6 @@ An example of this context could be:
 
    {
        "metadata": {
-           "slotNumber": 1,
-           "blockHeight": 1,
-           "finalizedHeight": 1,
            "slotTime": "2021-01-01T00:00:01Z"
        },
        "initOrigin": "3uxeCZwa3SxbksPWHwXWxCsaPucZdzNaXsRbkztqUUYRo1MnvF",
@@ -94,9 +91,6 @@ An example of this context could be:
 
    {
        "metadata": {
-           "slotNumber": 1,
-           "blockHeight": 1,
-           "finalizedHeight": 1,
            "slotTime": "2021-01-01T00:00:01Z"
        },
        "invoker": "3uxeCZwa3SxbksPWHwXWxCsaPucZdzNaXsRbkztqUUYRo1MnvF",

--- a/source/smart-contracts/references/host-fns.rst
+++ b/source/smart-contracts/references/host-fns.rst
@@ -114,29 +114,6 @@ Functions for reading information about the chain.
    :return: Time in milliseconds
    :rtype: i64
 
-.. function:: get_slot_number() -> i64
-
-   Get the slot number of the current block.
-
-   :return: Slot number
-   :rtype: i64
-
-.. function:: get_block_height() -> i64
-
-   Get block height of the current block.
-
-   :return: Block height
-   :rtype: i64
-
-.. function:: get_finalized_height() -> i64
-
-   Get the height of the last finalized block, i.e., block to which the
-   current block has a finalized pointer to.
-
-   :return: Finalized height
-   :rtype: i64
-
-
 Only in ``init``-function
 ================================
 Functions only accessible for smart contract ``init``-functions. If called from

--- a/source/smart-contracts/references/simulate-context.rst
+++ b/source/smart-contracts/references/simulate-context.rst
@@ -21,9 +21,6 @@ Example of context
 
     {
         "metadata": {
-            "slotNumber": 1,
-            "blockHeight": 1,
-            "finalizedHeight": 1,
             "slotTime": "2021-01-01T00:00:01Z"
         },
         "initOrigin": "3uxeCZwa3SxbksPWHwXWxCsaPucZdzNaXsRbkztqUUYRo1MnvF",
@@ -69,9 +66,6 @@ Example of context:
 
     {
         "metadata": {
-            "slotNumber": 1,
-            "blockHeight": 1,
-            "finalizedHeight": 1,
             "slotTime": "2021-01-01T00:00:01Z"
         },
         "invoker": "3uxeCZwa3SxbksPWHwXWxCsaPucZdzNaXsRbkztqUUYRo1MnvF",
@@ -182,38 +176,15 @@ Example:
 .. code-block:: json
 
    {
-         "slotNumber": 123456789,
-         "blockHeight": 123456789,
-         "finalizedHeight": 123456789,
          "slotTime": "2021-01-01T00:00:01Z"
    }
 
-
-``slotNumber``
---------------
-
-The slot number for the current block as a JSON number.
 
 ``slotTime``
 ------------
 
 The slot time at the beginning of the current block as a JSON string in the
 format of RFC3339_ with precision up to milliseconds.
-
-``blockHeight``
----------------
-
-The block height of the current block as a JSON number.
-
-
-``finalizedHeight``
--------------------
-
-The block height of the last finalized block as a JSON number.
-
-.. todo::
-
-   Link definition of finalized blocks
 
 .. _context-sender-policy:
 


### PR DESCRIPTION
They are removed from the next version of the smart contract libraries/API.