### PR TITLE
baker: reword some blurry concepts and time contraints

### DIFF
--- a/source/testnet/guides/accounts-transactions.rst
+++ b/source/testnet/guides/accounts-transactions.rst
@@ -12,6 +12,8 @@
 .. _Discord: https://discord.gg/xWmQ5tp
 
 
+.. _guide-account-transactions:
+
 =========================================================
 Concordium ID: Get started with accounts and transactions
 =========================================================

--- a/source/testnet/guides/become-baker.rst
+++ b/source/testnet/guides/become-baker.rst
@@ -16,13 +16,8 @@ Become a baker (create blocks)
    :local:
    :backlinks: none
 
-.. todo::
-
-   We need to address the user consistently; could we use the second person
-   and imperative (let's avoid writing 'the user')?
-
-This section explains what a baker is, its role in the network and how
-to become one.
+This section explains what a baker is, its role in the network and how to become
+one.
 
 By reading this section you will learn:
 
@@ -50,49 +45,24 @@ Definitions
 Baker
 -----
 
-A node is a *baker* (or *is baking*) when it actively participates in
-the network by creating new blocks that are added to the chain. A
-baker collects, orders and validates the transactions that are included in a
-block to maintain the integrity of the blockchain. The baker signs
-each block that they bake so that the block can be checked and executed by the rest of the
-participants of the network.
+A node is a *baker* (or *is baking*) when it actively participates in the
+network by creating new blocks that are added to the chain. A baker collects,
+orders and validates the transactions that are included in a block to maintain
+the integrity of the blockchain. The baker signs each block that they bake so
+that the block can be checked and executed by the rest of the participants of
+the network.
 
 Baker keys
 ----------
 
-Each baker has a set of cryptographic keys called *baker
-keys*. The node uses these keys to sign the blocks that it bakes. In order to
-bake blocks signed by a specific baker the node has to be running with its set
-of baker keys loaded.
+Each baker has a set of cryptographic keys called *baker keys*. The node uses
+these keys to sign the blocks that it bakes. In order to bake blocks signed by a
+specific baker the node has to be running with its set of baker keys loaded.
 
 Baker account
 -------------
 
-Each account in the network can register a unique set of baker
-keys that effectively registers a baker in the network, so this means
-that every account can choose whether to be a baker or not.
-
-.. todo:
-
-   - Should we say at this point how to register a baker? Otherwise it feels abstract.
-     The text about the baker ID (in the paragraph below) becomes less clear:
-     Does registration automatically yield a baker ID? Where does the baker ID come from?
-   - Could we remove the following sentence (it would be nice to write the text clearly
-     without needing that clarification, and possibly it is already written like that)?
-
-During this guide we will refer to the account that opted to be a baker simply
-as *the account*, *the baker account* or *the associated account*.
-
-.. todo:
-
-   Could we clarify why we mention a baker ID given that the baker ID is not needed
-   for any operation?
-
-Each registered baker is given a baker ID in the network. The baker ID is unique
-for each account so if an account removes its baker and then registers a new
-baker, it will have the same baker ID as the original baker. This ID merely tags
-the baker and is not needed to be provided for any operation, as the sender
-account already identifies which baker performed the operation.
+Each account can use a set of baker keys to register a baker.
 
 Whenever a baker bakes a valid block that gets included in the chain, after some
 time a reward is paid to the associated account.
@@ -102,14 +72,11 @@ Stake and lottery
 
 .. todo::
 
-   - Clarify what it means that the amount has to be *released* (first we need to say that
-     the amount needs to staked)
    - Link to release schedule.
-   - Reword "*holds* *some* stake".
 
-A baker holds some *stake* which is part of the amount of GTU owned by the
-account. The staked amount cannot be moved or transferred until it
-is released by the baker.
+The account can stake part of its GTU balance into the *baker stake* and can
+later manually release all or part of the staked amount. The staked amount
+cannot be moved or transferred until it is released by the baker.
 
 .. note::
 
@@ -119,6 +86,9 @@ is released by the baker.
 In order to be chosen for baking a block, the baker must participate in a
 *lottery* in which the probability of getting a winning ticket is roughly
 proportional to the staked amount.
+
+The same stake is used when calculating whether a baker is included in the finalization
+committee or not. See Finalization_.
 
 Epochs and slots
 ----------------
@@ -148,7 +118,7 @@ account. For a complete description, see :ref:`managing_accounts`.
 
 Accounts are created using the :ref:`concordium_id` app. Once an account has been
 successfully created, navigating to the **More** tab and selecting **Export**
-allows the user to get a JSON file containing the account information.
+allows you to get a JSON file containing the account information.
 
 To import an account into the toolchain run
 
@@ -168,32 +138,30 @@ Creating keys for a baker and registering it
    For this process the account needs to own some GTU so make sure to request the
    100 GTU drop for the account in the mobile app.
 
-.. todo::
+Each account has a unique baker ID that is used when registering its baker. This
+ID has to be provided by the network and currently cannot be precomputed. This
+ID must be given inside the baker keys file to the node so that it can use the
+baker keys to create blocks. The ``concordium-client`` will automatically fill
+this field when performing the following operations.
 
-   Clarify how the baker ID relates to the keys.
-
-As mentioned above, each account has a unique baker ID that is used when
-registering its baker. This ID has to be provided by the network and currently
-cannot be precomputed.
-
-To create a fresh set of keys run
+To create a fresh set of keys run:
 
 .. code-block:: console
 
    $concordium-client baker generate-keys <keys-file>.json
 
-where you can choose an arbitrary name the keys file. To
+where you can choose an arbitrary name for the keys file. To
 register the keys in the network you need to be :ref:`running a node <running-a-node>`
 and send a ``baker add`` transaction to the network:
 
 .. code-block:: console
 
-   $concordium-client baker add <file-name>.json --sender bakerAccount --stake <amountToStake> --out <concordium-data-dir>/baker-credentials.json
+   $concordium-client baker add <keys-file>.json --sender bakerAccount --stake <amountToStake> --out <concordium-data-dir>/baker-credentials.json
 
 replacing
 
 - ``<amountToStake>`` with the GTU amount for the baker's initial stake
-- ``<concordium-dir>`` with the following data directory:
+- ``<concordium-data-dir>`` with the following data directory:
 
   * on Linux and MacOS: ``~/.local/share/concordium``
   * on Windows: ``%LOCALAPPDATA%\\concordium``.
@@ -204,21 +172,35 @@ Provide a ``--no-restake`` flag to avoid automatically adding the
 rewards to the staked amount on the baker. This behavior is described on the
 section `Restaking the earnings`_.
 
-In order to start the node with these baker keys and start producing blocks the
-user first needs to shut down the current running node (either by pressing
+In order to start the node with these baker keys and start producing blocks you
+first need to shut down the current running node (either by pressing
 ``Ctrl + C`` on the terminal where the node is running or using the
 ``concordium-node-stop`` executable).
 
-After placing the file in the appropriate directory, start the
-node again using ``concordium-node``. The node will automatically start baking
-when the baker is included in the bakers for the current epoch. This will happen
-when finishing the epoch after the one in which the transaction for adding the
-baker was finalized.
+After placing the file in the appropriate directory (already done in the
+previous command when specifying the output file), start the node again using
+``concordium-node``. The node will automatically start baking when the baker
+gets included in the bakers for the current epoch.
+
+This change will be executed
+immediately and will take effect when finishing the epoch after the one in which
+the transaction for adding the baker was included in a block.
+
+.. table:: Timeline: adding a baker
+
+   +-------------------------------------------+-----------------------------------------+-----------------+
+   |                                           | When transaction is included in a block | After 2 epochs  |
+   +===========================================+=========================================+=================+
+   | Change is visible by querying the node    |  ✓                                      |                 |
+   +-------------------------------------------+-----------------------------------------+-----------------+
+   | Baker is included in the baking committee |                                         | ✓               |
+   +-------------------------------------------+-----------------------------------------+-----------------+
 
 .. note::
 
-   If the transaction for adding the baker was finalized during epoch `E`, the
-   baker will be active when epoch `E+2` starts.
+   If the transaction for adding the baker was included in a block during epoch `E`, the
+   baker will be considered as part of the baking committee when epoch
+   `E+2` starts.
 
 Managing the baker
 ==================
@@ -226,13 +208,13 @@ Managing the baker
 Checking the status of the baker and its lottery power
 ------------------------------------------------------
 
-In order to see if the node is baking, the user can check various sources that
+In order to see if the node is baking, you can check various sources that
 offer different degrees of precision in the information displayed.
 
-- In the `network dashboard <http://dashboard.testnet.concordium.com>`_, the
-  user's node will show its baker ID in the ``Baker`` column.
-- Using the ``concordium-client`` the user can check the list of current bakers
-  and the relative staked amount that they hold, i.e. its lottery power.  The
+- In the `network dashboard <http://dashboard.testnet.concordium.com>`_, your
+  node will show its baker ID in the ``Baker`` column.
+- Using the ``concordium-client`` you can check the list of current bakers
+  and the relative staked amount that they hold, i.e. their lottery power.  The
   lottery power will determine how likely it is that a given baker will win the
   lottery and bake a block.
 
@@ -248,7 +230,7 @@ offer different degrees of precision in the information displayed.
          34: 4p2n8QQn5akq3XqAAJt2a5CsnGhDvUon6HExd2szrfkZCTD4FX   <0.0001
          ...
 
-- Using the ``concordium-client`` the user can check that the account has
+- Using the ``concordium-client`` you can check that the account has
   registered a baker and the current amount that is staked by that baker.
 
   .. code-block:: console
@@ -261,10 +243,10 @@ offer different degrees of precision in the information displayed.
       - Restake earnings: yes
      ...
 
-- If the staked amount is big enough and there is a node running with the baker keys
-  loaded, that baker should eventually produce blocks and the user can see in
-  their mobile wallet that baking rewards are being received by the account, as
-  seen in this image:
+- If the staked amount is big enough and there is a node running with the baker
+  keys loaded, that baker should eventually produce blocks and you can see
+  in your mobile wallet that baking rewards are being received by the account,
+  as seen in this image:
 
   .. image:: images/bab-reward.png
      :align: center
@@ -279,25 +261,57 @@ To update the baker stake run
 
    $concordium-client baker update-stake --stake <newAmount> --sender bakerAccount
 
-Modifying the staked amount modifies the probability that a baker gets elected to bake blocks.
+Modifying the staked amount modifies the probability that a baker gets elected
+to bake blocks.
 
-When a baker adds stake for the first time or increases their stake:
+When a baker **adds stake for the first time or increases their stake**, that
+change is executed on the chain and becomes visible as soon as the transaction
+is included in a block (can be seen through ``concordium-client account show
+bakerAccount``) and takes effect 2 epochs after that.
 
-- That change becomes visible on the chain immediately (e.g. through ``concordium-client account show bakerAccount``)
-- The baker can bake (and possibly finalize, if stake is sufficient) after 2 epochs
+.. table:: Timeline: increasing the stake
 
-When a baker decreases the stake amount:
+   +----------------------------------------+-----------------------------------------+----------------+
+   |                                        | When transaction is included in a block | After 2 epochs |
+   +========================================+=========================================+================+
+   | Change is visible by querying the node | ✓                                       |                |
+   +----------------------------------------+-----------------------------------------+----------------+
+   | Baker uses the new stake               |                                         | ✓              |
+   +----------------------------------------+-----------------------------------------+----------------+
 
-- The change becomes visible on the chain after the *cooldown period* (currently 168 epochs)
+When a baker **decreases the staked amount**, the change will need *2 +
+bakerCooldownEpochs* epochs to take effect. The change becomes visible on the
+chain as soon as the transaction is included in a block, it can be consulted through
+``concordium-client account show bakerAccount``:
 
-  * - The pending change can also be queried immediately after the  using
-      ``concordium-client raw GetAccountInfo`` and observing the ``pendingChange`` attribute
+.. code-block:: console
 
-- The change takes effect after the cooldown period plus 2 epochs
+   $concordium-client account show bakerAccount
+   ...
+
+   Baker: #22
+    - Staked amount: 50.000000 GTU to be updated to 20.000000 GTU at epoch 261  (2020-12-24 12:56:26 UTC)
+    - Restake earnings: yes
+
+   ...
+
+.. table:: Timeline: decreasing the stake
+
+   +----------------------------------------+-----------------------------------------+----------------------------------------+
+   |                                        | When transaction is included in a block | After *2 + bakerCooldownEpochs* epochs |
+   +========================================+=========================================+========================================+
+   | Change is visible by querying the node | ✓                                       |                                        |
+   +----------------------------------------+-----------------------------------------+----------------------------------------+
+   | Baker uses the new stake               |                                         | ✓                                      |
+   +----------------------------------------+-----------------------------------------+----------------------------------------+
+   | Stake can be decreased again or        | ✗                                       | ✓                                      |
+   | baker can be removed                   |                                         |                                        |
+   +----------------------------------------+-----------------------------------------+----------------------------------------+
 
 .. note::
 
-   Check the value of the cooldown period as follows:
+   In the testnet, ``bakerCooldownEpochs`` is set initially to 168 epochs. This
+   value can be checked as follows:
 
    .. code-block:: console
 
@@ -306,32 +320,14 @@ When a baker decreases the stake amount:
               "bakerCooldownEpochs": 168
       ...
 
-
-.. todo::
-
-   Could the following sentence be clarified?
-
-When decreasing the stake, the user can then check when this change will be executed by querying for the account information:
-
-.. code-block:: console
-
-   $concordium-client account show bakerAccount
-   ...
-
-   Baker: #22
-    - Staked amount: 50.000000 GTU to be updated to 20.000000 GTU at epoch 261  (2020-12-24 12:56:26 UTC)
-    - Restake earnings: yes
-
-   ...
-
 .. warning::
 
    As noted in the `Definitions`_ section, the staked amount is *locked*,
-   i.e. it cannot be transferred or used for payment. The user should take
-   this into account and consider staking an amount that will not be
-   needed in the short term. In particular, to deregister a baker or to
-   modify the staked amount the user needs to own some non-staked GTU to
-   cover the transaction costs.
+   i.e. it cannot be transferred or used for payment. You should take this
+   into account and consider staking an amount that will not be needed in the
+   short term. In particular, to deregister a baker or to modify the staked
+   amount you need to own some non-staked GTU to cover the transaction
+   costs.
 
 Restaking the earnings
 ----------------------
@@ -340,7 +336,7 @@ When participating as a baker in the network and baking blocks, the account
 receives rewards on each baked block. These rewards are automatically added to
 the staked amount by default.
 
-The user can choose to modify this behavior and instead receive the rewards in
+You can choose to modify this behavior and instead receive the rewards in
 the account balance without staking them automatically. This switch can be
 changed through ``concordium-client``:
 
@@ -349,10 +345,10 @@ changed through ``concordium-client``:
    $concordium-client baker update-restake False --sender bakerAccount
    $concordium-client baker update-restake True --sender bakerAccount
 
-Changes to the restake flag will take effect immediately; however, the changes start
-affecting baking and finalizing power in the epoch after next.
-The current value of the switch can be seen in the account
-information which can be queried using ``concordium-client``:
+Changes to the restake flag will take effect immediately; however, the changes
+start affecting baking and finalizing power in the epoch after next. The current
+value of the switch can be seen in the account information which can be queried
+using ``concordium-client``:
 
 .. code-block:: console
 
@@ -360,10 +356,23 @@ information which can be queried using ``concordium-client``:
    ...
 
    Baker: #22
-    - Staked amount: 50.000000 GTU to be updated to 20.000000 GTU at epoch 261  (2020-12-24 12:56:26 UTC)
+    - Staked amount: 50.000000 GTU
     - Restake earnings: yes
 
    ...
+
+.. table:: Timeline: updating restake
+
+   +-----------------------------------------------+-----------------------------------------+-------------------------------+
+   |                                               | When transaction is included in a block | 2 epochs after being rewarded |
+   +===============================================+=========================================+===============================+
+   | Change is visible by querying the node        | ✓                                       |                               |
+   +-----------------------------------------------+-----------------------------------------+-------------------------------+
+   | Earnings will [not] be restaked automatically | ✓                                       |                               |
+   +-----------------------------------------------+-----------------------------------------+-------------------------------+
+   | If restaking automatically, the gained        |                                         | ✓                             |
+   | stake affects the lottery power               |                                         |                               |
+   +-----------------------------------------------+-----------------------------------------+-------------------------------+
 
 When the baker is registered, it will automatically re-stake the earnings, but as
 mentioned above, this can be changed by providing the ``--no-restake`` flag to
@@ -376,28 +385,28 @@ the ``baker add`` command as shown here:
 Finalization
 ------------
 
-Finalization is the voting process performed by nodes
-in the *finalization committee* that *finalizes* a block when a sufficiently big
-number of members of the committee have received the block and agree on its
-outcome. Newer blocks must have the finalized block as an ancestor to ensure the
-integrity of the chain. For more information about this process, see the
-:ref:`glossary_finalization` section.
+Finalization is the voting process performed by nodes in the *finalization
+committee* that *finalizes* a block when a sufficiently big number of members of
+the committee have received the block and agree on its outcome. Newer blocks
+must have the finalized block as an ancestor to ensure the integrity of the
+chain. For more information about this process, see the
+:ref:`finalization<glossary-finalization>` section.
 
 The finalization committee is formed by the bakers that have a certain staked
 amount. This specifically implies that in order to participate in the
-finalization committee the user will probably have to modify the staked amount
+finalization committee you will probably have to modify the staked amount
 to reach said threshold. In the testnet, the staked amount needed to participate
 in the finalization committee is **0.1% of the total amount of existing GTU**.
 
 Participating in the finalization committee produces rewards on each block that
-is finalized. The rewards are paid to the baker account some time after the block is
-finalized.
+is finalized. The rewards are paid to the baker account some time after the
+block is finalized.
 
 Removing a baker
 ================
 
 The controlling account can choose to de-register its baker on the chain. To do
-so the user has to execute the ``concordium-client``:
+so you have to execute the ``concordium-client``:
 
 .. code-block:: console
 
@@ -406,10 +415,11 @@ so the user has to execute the ``concordium-client``:
 This will remove the baker from the baker list and unlock the staked amount on
 the baker so that it can be transferred or moved freely.
 
-When removing the baker, there is a **cooldown period** (check `Updating the
-staked amount`_ above for more information about this value) during which the
-operation is queued but not yet executed. The user can check when this takes
-effect by querying the account information with ``concordium-client`` as usual:
+When removing the baker, the change has the same timeline as decreasing
+the staked amount. The change will need *2 + bakerCooldownEpochs* epochs to take effect.
+The change becomes visible on the chain as soon as the transaction is included in a block and you
+can check when this change will be take effect by querying the account information
+with ``concordium-client`` as usual:
 
 .. code-block:: console
 
@@ -421,6 +431,16 @@ effect by querying the account information with ``concordium-client`` as usual:
     - Restake earnings: yes
 
    ...
+
+.. table:: Timeline: removing a baker
+
+   +--------------------------------------------+-----------------------------------------+----------------------------------------+
+   |                                            | When transaction is included in a block | After *2 + bakerCooldownEpochs* epochs |
+   +============================================+=========================================+========================================+
+   | Change is visible by querying the node     | ✓                                       |                                        |
+   +--------------------------------------------+-----------------------------------------+----------------------------------------+
+   | Baker is removed from the baking committee |                                         | ✓                                      |
+   +--------------------------------------------+-----------------------------------------+----------------------------------------+
 
 .. warning::
 

--- a/source/testnet/references/id-accounts.rst
+++ b/source/testnet/references/id-accounts.rst
@@ -7,6 +7,8 @@
 .. _`Concordium ID`: /test/guides/get-started.html
 .. _Discord: https://discord.com/invite/xWmQ5tp
 
+.. _reference-id-accounts:
+
 =======================
 Identities and accounts
 =======================

--- a/source/testnet/references/query-node.rst
+++ b/source/testnet/references/query-node.rst
@@ -35,6 +35,8 @@ a backend node:
    statistics related to baking and finalization of blocks.
 
 
+.. _query-account-state:
+
 Account state
 =============
 

--- a/source/testnet/references/transactions.rst
+++ b/source/testnet/references/transactions.rst
@@ -1,24 +1,9 @@
-.. _Concordium ID (mobile wallet): #concordium-id-mobile-wallet-
+.. _Concordium ID (mobile wallet): #concordium-id-mobile-wallet
 .. _Command-line tool: #command-line-tool
 .. _Transfer: #transfer
 .. _Encrypted transfer: #encrypted-transfer
 .. _Shield an amount: #shield-an-amount
 .. _Unshield an amount: #unshield-an-amount
-.. _account: /testnet/docs/glossary#account
-.. _stake delegation: /testnet/docs/glossary#stake-delegation
-.. _adding a baker: /testnet/docs/quickstart-baker
-.. _block: /testnet/docs/glossary#baker
-.. _sequence number: /testnet/docs/glossary#transaction-sequence-number
-.. _finalized: /testnet/docs/glossary#finalization
-.. _Concordium ID: /testnet/docs/downloads#concordium-id
-.. _concordium-client: /testnet/docs/client
-.. _an account: /testnet/docs/identities-and-accounts
-.. _wallet: /testnet/docs/quickstart-wallet#before-you-start
-.. _importing the account: /testnet/docs/managing-accounts
-.. _becoming a baker: /testnet/docs/quickstart-baker
-.. _incoming encrypted amounts: /testnet/docs/glossary#incoming-encrypted-amount
-.. _Querying an account: /testnet/docs/queries#account-state
-.. _self balance: /testnet/docs/glossary#self-balance
 .. _Discord: https://discord.com/invite/xWmQ5tp
 
 .. _transactions:
@@ -32,13 +17,13 @@ Transactions
    :backlinks: none
 
 A *transaction* is an operation which applies some change to the chain.
-Transactions always have one sender `account`_ and are signed using the keys of
+Transactions always have one sender :ref:`account<glossary-account>` and are signed using the keys of
 this account.
 
 There are several transaction types: The most basic one is a GTU transfer, which
 moves tokens from the sender account to another account. Other transaction types
-include encrypted transfers, `stake delegation`_, `adding a baker`_, and
-updating keys of accounts and bakers.
+include encrypted transfers, :ref:`adding a baker<become-a-baker>`, and updating keys of accounts
+and bakers.
 
 Every transaction has a well-defined *cost*, the value of which depends on the
 transaction type as well as the payload in a way that reflects the computational
@@ -49,7 +34,7 @@ NRG which corresponds to GTU according to a variable conversion factor
 (currently 1 NRG = 0.0001 GTU).
 
 Once a baker receives a transaction from some client, it performs a few basic
-checks to verify that the transaction is eligible for *inclusion* in a `block`_.
+checks to verify that the transaction is eligible for *inclusion* in a :ref:`block<glossary-block>`.
 If any of these checks fail, the transaction is ignored. Included transactions
 which satisfy all further requirements are considered *successful* and have
 their changes applied to the chain. If something doesn't check out (for
@@ -57,17 +42,17 @@ instance, the sender attempted to overdraw their account), the transaction is
 still included, but recorded as *rejected*. A rejected transaction has no effect
 other than deducting its cost from the sender.
 
-Each account has a `sequence number`_ associated with it. This number increases
+Each account has a :ref:`sequence number<glossary-transaction-sequence-number>` associated with it. This number increases
 sequentially with each transaction sent from this account and is recorded into
 the transaction. Transactions with sequence numbers that don't match the current
 one of the account are not considered eligible for inclusion on the chain. This
 ensures that transactions are included only once and in a specific order.
 
-Until some block containing a given transaction is `finalized`_, there is no
+Until some block containing a given transaction is :ref:`finalized<glossary-finalization>`, there is no
 guarantee that the transaction is permanent.
 
-Transfers (both plain and encrypted) can be performed using the `Concordium ID`_
-mobile app, or the concordium-client_ tool. All other transaction types
+Transfers (both plain and encrypted) can be performed using the :ref:`Concordium ID<concordium_id>`
+mobile app, or the :ref:`concordium-client<concordium_client>` tool. All other transaction types
 can only be done through ``concordium-client``.
 
 
@@ -75,7 +60,7 @@ can only be done through ``concordium-client``.
 Concordium ID (mobile wallet)
 =============================
 
-Once you create `an account`_ in the `wallet`_, the **SEND** button brings you
+Once you create :ref:`an account<reference-id-accounts>` in the :ref:`wallet<guide-account-transactions>`, the **SEND** button brings you
 to the screen for doing transfers from the given account. Depending on whether
 you are in the public or shielded balance part of the account the transfer will
 be a plain transfer, or an encrypted transfer.
@@ -83,7 +68,7 @@ be a plain transfer, or an encrypted transfer.
 Command-line tool
 =================
 
-All types of transactions can be performed using concordium-client_. The
+All types of transactions can be performed using :ref:`concordium-client<concordium_client>`. The
 different transaction types are performed using specialized subcommands:
 
 +-------------------------------+-------------------------------------+
@@ -101,17 +86,12 @@ different transaction types are performed using specialized subcommands:
 +-------------------------------+-------------------------------------+
 | ``baker remove``              | Remove a baker                      |
 +-------------------------------+-------------------------------------+
-| ``baker set-account``         | Update reward account of a baker    |
+| ``baker update-stake``        | Update the staked amount of a baker |
 +-------------------------------+-------------------------------------+
-| ``baker set-key``             | Update signature key of a baker     |
-+-------------------------------+-------------------------------------+
-| ``baker set-aggregation-key`` | Update aggregation key of a baker   |
-+-------------------------------+-------------------------------------+
-| ``account delegate``          | Deletegate an account's stake to a  |
+| ``baker update-restake``      | Update the restaking switch of a    |
 |                               | baker                               |
 +-------------------------------+-------------------------------------+
-| ``account undelegate``        | Ensure that an account's stake is   |
-|                               | not delegated                       |
+| ``baker set-key``             | Update the keys of a baker          |
 +-------------------------------+-------------------------------------+
 | ``account add-keys``          | Add additional signing keys to the  |
 |                               | account                             |
@@ -131,7 +111,7 @@ common set of flags and configuration to control how they build transactions.
 Depending on the exact context, the flags are currently all optional:
 
 -  ``--sender``: Name or address of the transaction's sender account.
-   The name is the one used when `importing the account`_ (assuming that this
+   The name is the one used when :ref:`importing the account<managing_accounts>` (assuming that this
    was done). Defaults to the account name "default".
 -  ``--keys``: A number of sign/verify key-pairs associated with the
    account, used to sign the transaction. The format is shown in the example
@@ -155,14 +135,17 @@ Just before the transaction is sent the user is asked for the password to access
 the signing keys.
 
 Once a transaction has been submitted, the command will continuously poll and
-display its status until it's been `finalized`_.
+display its status until it's been :ref:`finalized<glossary-finalization>`.
 
-The command for transferring GTU is described below. The remaining commands are
-used to add, remove, and configure bakers as well as delegating stake to them.
-They expose a lower level, but more versatile set of features compared to the
-tools described in the quickstart on `becoming a baker`_. As such, they are
-considered "advanced" for now and not further explained. For more information
-about a command, invoke it with the ``--help`` flag.
+The commands for transferring GTU (both plain transfers and encrypted transfers)
+are described below.
+
+The remaining commands are used to add, remove, and configure bakers. Their
+behavior is explained on the guide for :ref:`becoming a baker<become-a-baker>`.
+
+.. note::
+
+   For more information about a command, invoke it with the ``--help`` flag.
 
 Transfer
 --------
@@ -260,8 +243,8 @@ The interaction looks as follows.
 
 This command has all of the additional options of ``send-gtu``, as well as an
 additional flag ``--index.`` This flag, if given, is used to select which
-`incoming encrypted amounts`_ that will be used as input to the transaction.
-This is best illustrated on an example. `Querying an account`_ can display the
+:ref:`incoming encrypted amounts<glossary-incoming-encrypted-amount>` that will be used as input to the transaction.
+This is best illustrated on an example. :ref:`Querying an account<query-account-state>` can display the
 list of incoming amounts on account. An output could look as follows
 
 .. code-block:: console
@@ -276,7 +259,7 @@ list of incoming amounts on account. An output could look as follows
    ...
 
 If we were to ``send-gtu-encrypted`` from the account while supplying index 8,
-only the encrypted amount ``8c0faff6739bffc531c5...`` and the `self balance`_
+only the encrypted amount ``8c0faff6739bffc531c5...`` and the :ref:`self balance<glossary-self-balance>`
 would be used as input of the encrypted transfer.
 
 If the supplied index is out of range ``concordium-client`` will refuse to send

--- a/source/testnet/see-also/glossary.rst
+++ b/source/testnet/see-also/glossary.rst
@@ -53,7 +53,7 @@ Best chain
 
 The chain a :ref:`baker<glossary-baker>` will build upon when making a new block. The best chain
 selection procedure is determined by the consensus protocol. In particular, the
-best chain has the most :ref:`finalized<glossary_finalization>` blocks, and the most blocks after the last
+best chain has the most :ref:`finalized<glossary-finalization>` blocks, and the most blocks after the last
 finalized block.
 
 .. _glossary-block:
@@ -92,7 +92,7 @@ Consensus
 =========
 
 The process by which nodes agree which :ref:`transaction<glossary-transaction>` have occurred and in what
-order. This consists of :ref:`baking<glossary-baker>` and :ref:`finalization<glossary_finalization>`.
+order. This consists of :ref:`baking<glossary-baker>` and :ref:`finalization<glossary-finalization>`.
 
 .. _glossary-credential:
 
@@ -140,7 +140,7 @@ for approximately one hour). At the start of each epoch, we compute a
 :ref:`leadership election nonce<glossary-leader-election>` based on the block nonces of the previous epoch.
 The leadership election nonce is valid for the duration of the epoch.
 
-.. _glossary_finalization:
+.. _glossary-finalization:
 
 Finalization
 ============
@@ -170,7 +170,7 @@ purposes:
 -  as a form of payment between users via transactions,
 -  as a payment for executing smart contracts,
 -  as a store of value,
--  as a reward for honest behaviour (e.g. :ref:`baking<glossary-baker>` or :ref:`finalizing<glossary_finalization>`
+-  as a reward for honest behaviour (e.g. :ref:`baking<glossary-baker>` or :ref:`finalizing<glossary-finalization>`
    blocks on top of the longest chain), to incentivize blockchain users.
 
 The smallest subdivision of GTU is the µGTU (micro GTU), with 1 GTU = 1,000,000
@@ -270,7 +270,7 @@ Node
 
 A participant in the Concordium network. Nodes receive blocks and transactions,
 and track the current state of the blockchain. A :ref:`baker node<glossary-baker>` has cryptographic
-keys that enable it to take part in baking and :ref:`finalization<glossary_finalization>`. A node without
+keys that enable it to take part in baking and :ref:`finalization<glossary-finalization>`. A node without
 these keys is referred to as a *passive node*.
 
 .. _glossary-nonce:


### PR DESCRIPTION
Reworded how we specify the different time constraints to try to give a consistent view of the timeline. Also removed the definition of baker ID as we don't really need it.