### PR TITLE
Changed incorrect phrasing

### DIFF
--- a/source/testnet/guides/accounts-transactions.rst
+++ b/source/testnet/guides/accounts-transactions.rst
@@ -111,7 +111,7 @@ Move an amount to the shielded balance
 ========================================
 If we go back to the *Accounts* screen, we can now see that the 10 GTU has been transferred to the *Balance* of *Example Account 1*. As you might
 have noticed before, the accounts also have a :ref:`glossary-shielded-balance`. In short, the shielded balance is for keeping shielded (encrypted) amounts
-of GTU on the account. Lets’ try adding some shielded GTU to our *Example Account 2*. Start by pressing the **Shielded Balance** area of the account card.
+of GTU on the account. Let’s try adding some shielded GTU to our *Example Account 2*. Start by pressing the **Balance** area of the account card.
 
 .. image:: images/concordium-id/acc19.png
       :width: 32%


### PR DESCRIPTION
## Purpose

The purpose of this pull request, is just to change a small phrasing error in the guide on how to move funds to the shielded balance.

Resolves #93 

## Changes

Lets' was changed to Let's, and **Shielded Balance** was changed to **Balance**

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
