### PR TITLE
Enable caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ linkcheck:
 	@$(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)"
 
 dev:
-	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)/html" -E
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)/html"
 
 lint:
 	doc8 "$(SOURCEDIR)"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,16 @@ directives
 
    Write a todo here
 ```
-Todos are shown as warnings when building the docs.
+
+To show TODOs as warnings when building the docs you need to uncomment the
+following line in `/source/conf.py`:
+
+```
+# todo_emit_warnings = True
+```
+
+NB: This will only show TODOs for the files being built; as opposed to TODOs
+from all files.
 
 To generate SVG graphics, we use the [Graphviz
 extension](https://www.sphinx-doc.org/en/master/usage/extensions/graphviz.html).

--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ Before committing, make sure to try to build and fix any warnings that are repor
 ```
 
 
-> **Note**: In `make dev` we disable the cache on build as this tends to cause
-> inconsistencies. If the build time becomes too slow, it might be worth
-> enabling again by removing `-E`.
-
+> **Note**:
+> When working on changes to the design it can be benefitial to disable
+> caching, as it can cause UI problems. To disable it, add the `-E` flag to the
+> `dev` command in the appropriate make file.
 
 ## Building the docs
 Run the following command:

--- a/make.bat
+++ b/make.bat
@@ -31,7 +31,7 @@ if errorlevel 9009 (
 goto end
 
 :dev
-sphinx-autobuild.exe %SOURCEDIR% %BUILDDIR/html -E
+sphinx-autobuild.exe %SOURCEDIR% %BUILDDIR/html
 goto end
 
 :lint


### PR DESCRIPTION
## Purpose

Enable caching of builds.
Explain how to get warnings from TODOs.

## Changes

- Removing the `-E` flag from the make files.
- Update the README

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
