### PR TITLE
Add support and feedback section to be appended in every rst file

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -134,6 +134,14 @@ current_version = os.environ['current_version'] if 'current_version' in os.envir
 versions = os.environ['all_versions'].split(",") if 'all_versions' in os.environ else [current_version]
 languages = os.environ['all_languages'].split(",") if 'all_languages' in os.environ else [current_language]
 
+rst_epilog = """
+Support & Feedback
+==================
+
+If you have questions or feedback, join us on `Discourse <https://support.concordium.software/>`_, or contact us at support@concordium.software.
+"""
+
+
 html_context = {
     "display_github": True,
     "github_user": "Concordium",

--- a/source/testnet/concepts/id-accounts.rst
+++ b/source/testnet/concepts/id-accounts.rst
@@ -132,9 +132,3 @@ de-anonymized accounts.
 All of these actions are subject to rules and processes, and only the relevant
 entities learn any information about the account owner. No information is
 publicly revealed.
-
-Support & Feedback
-==================
-
-If you run into any issues or have suggestions, post your question or feedback
-on `Discord`_, or contact us at testnet@concordium.com.

--- a/source/testnet/guides/accounts-transactions.rst
+++ b/source/testnet/guides/accounts-transactions.rst
@@ -224,9 +224,3 @@ make a transfer with a release schedule, you can have a look at the :ref:`concor
       :width: 32%
 .. image:: ../images/concordium-id/rel3.png
       :width: 32%
-
-Support & Feedback
-==================
-
-If you run into any issues or have suggestions, post your question or
-feedback on `Discord`_, or contact us at testnet@concordium.com.

--- a/source/testnet/guides/become-baker.rst
+++ b/source/testnet/guides/become-baker.rst
@@ -333,9 +333,3 @@ the staked amount. The change will need *2 + bakerCooldownEpochs* epochs to take
    Decreasing the staked amount and removing the baker can't be done
    simultaneously. During the cooldown period produced by decreasing the staked
    amount, the baker can't be removed and vice versa.
-
-Support & Feedback
-==================
-
-If you run into any issues or have suggestions, post your question or
-feedback on `Discord`_, or contact us at testnet@concordium.com.

--- a/source/testnet/guides/run-node.rst
+++ b/source/testnet/guides/run-node.rst
@@ -175,7 +175,7 @@ the client, it will keep running in the background in Docker. In that
 case, use the ``concordium-node-stop`` binary in the same way you opened
 the ``concordium-node`` executable.
 
-Support & Feedback
+Retrieve node logs
 ==================
 
 Logging information for your node can be retrieved using the

--- a/source/testnet/index.rst
+++ b/source/testnet/index.rst
@@ -58,12 +58,3 @@ Mainnet
    resources/glossary
    resources/release-notes
    resources/third-party-licenses
-
-Support & Feedback
-==================
-
-If you run into any issues or have suggestions, post your question or feedback
-on Discord_, or contact us at `testnet@concordium.com`_.
-
-.. _Discord: https://discord.gg/xWmQ5tp
-.. _`testnet@concordium.com`: mailto:testnet@concordium.com

--- a/source/testnet/installation/get-the-app.rst
+++ b/source/testnet/installation/get-the-app.rst
@@ -44,9 +44,3 @@ Installing the Concordium ID app on iOS requires installation of Apple’s TestF
 2. Join our `TestFlight beta program`_ via your iPhone (it works best if you click the link directly on your iPhone), and follow the steps shown in there, to add Concordium ID to TestFlight.
 3. Open the TestFlight app on your iPhone and install Concordium ID.
 
-
-Support & Feedback
-==================
-
-If you run into any issues or have suggestions, post your question or
-feedback on `Discord`_, or contact us at testnet@concordium.com.

--- a/source/testnet/mobile-wallet/explore-more.rst
+++ b/source/testnet/mobile-wallet/explore-more.rst
@@ -41,9 +41,3 @@ the addresses of your own accounts are already stored there. Besides seeing your
 the *Address Book*, either by pressing the **QR code symbol**, or pressing the **plus sign** in the upper right corner. By doing that you
 can enter a new recipient address and give it a nickname in your *Address Book*. The entries in your address book can of course be
 searched, when you make a transfer.
-
-Support & Feedback
-==================
-
-If you run into any issues or have suggestions, post your question or
-feedback on `Discord`_, or contact us at testnet@concordium.com.

--- a/source/testnet/mobile-wallet/get-started.rst
+++ b/source/testnet/mobile-wallet/get-started.rst
@@ -81,9 +81,3 @@ account. It might be showing a *Pending icon*, which means the identity provider
 initial account and identity. You can also navigate to the *Identities screen* by clicking on **Identities** at the bottom of the
 display. On this screen you can see your newly created identity, which might also still be pending in case the identity provider
 has not finished it yet. All you have to do now, is wait for them to finish.
-
-Support & Feedback
-==================
-
-If you run into any issues or have suggestions, post your question or
-feedback on `Discord`_, or contact us at testnet@concordium.com.

--- a/source/testnet/references/concordium-client.rst
+++ b/source/testnet/references/concordium-client.rst
@@ -301,9 +301,3 @@ Replace ``--bash-completion-script`` by ``--zsh-completion-script`` or
 See the documentation of the `framework`_ used to implement the command
 structure of ``concordium-client`` for more details.
 
-Support & Feedback
-==================
-
-If you run into any issues or have suggestions, post your question or feedback
-on `Discord`_, or contact us at testnet@concordium.com.
-

--- a/source/testnet/references/manage-accounts.rst
+++ b/source/testnet/references/manage-accounts.rst
@@ -136,12 +136,6 @@ Concordium blockchain. It cannot be used to create identities, but it can
 imported, the tool can be used to do GTU transfers from the account, as well as
 send all other :ref:`transaction<transactions>` types supported by the Concordium blockchain.
 
-Support & Feedback
-==================
-
-If you run into any issues or have suggestions, post your question or
-feedback on Discord_, or contact us at testnet@concordium.com.
-
 
 .. rubric:: Footnotes
 

--- a/source/testnet/references/query-node.rst
+++ b/source/testnet/references/query-node.rst
@@ -302,9 +302,3 @@ If an update transaction has been posted it will take time to take effect. You c
 whether updates to the chain parameters are being processed by looking for attributes
 that are prefixed with ``pending`` in the result of the above query.
 
-Support & Feedback
-==================
-
-If you run into any issues or have suggestions, post your question or feedback
-on `Discord`_, or contact us at testnet@concordium.com.
-

--- a/source/testnet/references/transactions.rst
+++ b/source/testnet/references/transactions.rst
@@ -396,9 +396,3 @@ list of releases that are still pending to be released:
 The amount that is not yet released is also accounted in the ``Balance`` field
 so in this case the account owns ``100 GTU`` that don't belong to any pending
 release schedule.
-
-Support & Feedback
-==================
-
-If you run into any issues or have suggestions, post your question or
-feedback on `Discord`_, or contact us at testnet@concordium.com.


### PR DESCRIPTION
## Purpose

To ensure consistency, the support and feedback footer should be defined once and reused across the pages.

## Changes

- Added the footer using the sphinx setting [`rst_epilog`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-rst_epilog)
- Removed the support and feedback section from every rst file