### PR TITLE
Add link to testnet4 page for mainnet documentation

### DIFF
--- a/source/_templates/index.html
+++ b/source/_templates/index.html
@@ -16,8 +16,8 @@
     <div class="logo-container">
         <img class="logo" src="{{pathto('_static/concordium-logo-dark.svg', 1)}}" />
         <h1>Documentation</h1>
-        <p>The documentation can be found here, as soon as we have released Mainnet.</p>
-        <p>Keep an eye out for news <a href='https://medium.com/concordium'>here</a>.</p>
+        <p>The documentation for the Concordium Testnet4 is no longer available.</p>
+        <p>The Mainnet documentation can be found <a href='/'>here</a></p>
     </div>
 
     <style>


### PR DESCRIPTION
## Purpose

The outdated testnet4 documentation should have a link to the current mainnet documentation.
Should be merged and deployed at mainnet launch.


## Changes

- Add link to testnet4 page for mainnet documentation