### PR TITLE
CI checks build using scripts/build.sh

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,4 +48,4 @@ jobs:
 
       - name: Build 🛠
         shell: bash
-        run: sphinx-build source build -W
+        run: ./scripts/build.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,6 +41,6 @@ for current_version in ${versions[@]}; do
   for current_language in ${languages[@]}; do
     export current_language
     printf "\nRunning build '${current_version}' for language '${current_language}'\n"
-    sphinx-build "${source_dir}" "${build_dir}/${current_language}" -c "${source_dir}/${current_version}" -D language="${current_language}"
+    sphinx-build "${source_dir}" "${build_dir}/${current_language}" -c "${source_dir}/${current_version}" -D language="${current_language}" -W
   done
 done


### PR DESCRIPTION
## Purpose

Currently, the build check fails, because it is not using the build script

## Changes

- Make the build check, use the build script
