### PR TITLE
Remove trailing comma to make json valid

### DIFF
--- a/source/shared/smart-contracts/guides/local-simulate.rst
+++ b/source/shared/smart-contracts/guides/local-simulate.rst
@@ -56,7 +56,7 @@ An example of this context could be:
            "identityProvider": 1,
            "createdAt": "202012",
            "validTo": "202109"
-       }],
+       }]
    }
 
 .. seealso::


### PR DESCRIPTION
## Purpose

Make the json valid by removing the trailing comma.