### PR TITLE
Explain how to run C. client and cargo-concordium on mac

### DIFF
--- a/source/mainnet/net/installation/downloads.rst
+++ b/source/mainnet/net/installation/downloads.rst
@@ -68,6 +68,12 @@ Download the Concordium Client:
 
 -  `Download the Concordium Client for macOS <https://distribution.concordium.software/tools/macos/concordium-client_1.0.1>`_.
 
+   - You need to make the client executable by running ``chmod +x
+     path/to/concordium-client_1.0.1`` in a terminal. Make sure to provide the
+     correct path to the downloaded client.
+   - You also need to `grant it permission to run in your Security & Privacy
+     settings <https://support.apple.com/en-gb/guide/mac-help/mh40616/mac>`_.
+
 -  `Download the Concordium Client for Windows <https://distribution.concordium.software/tools/windows/concordium-client_1.0.1.exe>`_
 
 
@@ -78,6 +84,12 @@ Download cargo-concordium:
 -  `Download cargo-concordium for Linux <https://distribution.concordium.software/tools/linux/cargo-concordium_1.0.0>`_
 
 -  `Download cargo-concordium for MacOS <https://distribution.concordium.software/tools/macos/cargo-concordium_1.0.0>`_
+
+   - You need to make the tool executable by running ``chmod +x
+     path/to/cargo-concordium_1.0.0`` in a terminal. Make sure to provide the
+     correct path to the downloaded tool.
+   - You also need to `grant it permission to run in your Security & Privacy
+     settings <https://support.apple.com/en-gb/guide/mac-help/mh40616/mac>`_.
 
 -  `Download cargo-concordium for Windows <https://distribution.concordium.software/tools/windows/cargo-concordium_1.0.0.exe>`_
 

--- a/source/testnet/net/installation/downloads.rst
+++ b/source/testnet/net/installation/downloads.rst
@@ -40,6 +40,12 @@ Download the Concordium Client:
 
 -  `Download the Concordium Client for macOS <https://distribution.concordium.software/tools/macos/concordium-client_1.0.1>`_.
 
+   - You need to make the client executable by running ``chmod +x
+     path/to/concordium-client_1.0.1`` in a terminal. Make sure to provide the
+     correct path to the downloaded client.
+   - You also need to `grant it permission to run in your Security & Privacy
+     settings <https://support.apple.com/en-gb/guide/mac-help/mh40616/mac>`_.
+
 -  `Download the Concordium Client for Windows <https://distribution.concordium.software/tools/windows/concordium-client_1.0.1.exe>`_
 
 
@@ -50,6 +56,12 @@ Download cargo-concordium:
 -  `Download cargo-concordium for Linux <https://distribution.concordium.software/tools/linux/cargo-concordium_1.0.0>`_
 
 -  `Download cargo-concordium for MacOS <https://distribution.concordium.software/tools/macos/cargo-concordium_1.0.0>`_
+
+   - You need to make the tool executable by running ``chmod +x
+     path/to/cargo-concordium_1.0.0`` in a terminal. Make sure to provide the
+     correct path to the downloaded tool.
+   - You also need to `grant it permission to run in your Security & Privacy
+     settings <https://support.apple.com/en-gb/guide/mac-help/mh40616/mac>`_.
 
 -  `Download cargo-concordium for Windows <https://distribution.concordium.software/tools/windows/cargo-concordium_1.0.0.exe>`_
 


### PR DESCRIPTION
## Purpose

We had few support issues regarding running our command-line tools on mac.
This should help amend this issue.

We might also need to address the issue that people without knowledge of terminal usage is downloading our terminal tools.

## Changes

- Describe how to make the tool executable with `chmod` and how to grant it permission to run.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.