### PR TITLE
Added description for non-signed Mac software

### DIFF
--- a/source/testnet/net/installation/downloads.rst
+++ b/source/testnet/net/installation/downloads.rst
@@ -35,6 +35,8 @@ Simply click **More info**, and then **Run anyway**. Windows might also ask you,
 
 - `Download the Testnet version of Concordium Desktop Wallet for MacOS. <https://distribution.testnet.concordium.com/tools/macos/concordium-desktop-wallet-testnet-1.1.3.dmg>`_
 
+MacOS might block the Desktop Wallet the first time you try to run it, but you will be able to allow it to run in System Preferences, via the Security & Privacy menu.
+
 Currently, the Desktop Wallet doesn't support Apple M1 Macs.
 
 - Download the Testnet version of Concordium Desktop Wallet for Linux:


### PR DESCRIPTION
## Purpose

The testnet version of the DW for MacOS is not signed, so a description of how to allow it to run was added to the downloads page. 

## Changes

The description on how to allow the DW to run on MacOS was added.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
