### PR TITLE
Split Client transaction topic into two: conceptual and Concordium Cl…

### DIFF
--- a/source/mainnet/net/concepts/concepts-transactions.rst
+++ b/source/mainnet/net/concepts/concepts-transactions.rst
@@ -1,0 +1,2 @@
+
+.. include:: /../shared/net/concepts/concepts-transactions.rst

--- a/source/mainnet/net/index.rst
+++ b/source/mainnet/net/index.rst
@@ -31,6 +31,7 @@
 
    concepts/id-accounts
    concepts/concepts-baker
+   concepts/concepts-transactions
 
 .. toctree::
    :maxdepth: 1

--- a/source/shared/net/concepts/concepts-transactions.rst
+++ b/source/shared/net/concepts/concepts-transactions.rst
@@ -1,0 +1,43 @@
+.. _transactions-overview:
+
+=====================
+Transactions overview
+=====================
+
+.. contents::
+    :local:
+    :backlinks: none
+
+A transaction on the Concordium blockchain is an operation which applies some change to the chain. All transactions are recorded on the chain and once recorded, they are immutable . A transaction always has one sender :ref:`account<glossary-account>` and is signed using the keys of this account.
+
+The most basic transaction is the GTU transfer that is used to send GTU from one account to another. However, there are several transaction types on the Concordium blockchain:
+
+- Send GTU
+- Shield GTU
+- Unshield GTU
+- Add baker
+- Remove baker
+- Update baker stake
+- Update restake earnings
+- Update baker keys
+- Update account credentials
+
+You can make transactions using either the Desktop Wallet, the Mobile Wallet, or the Concordium Client. Note that the Mobile Wallet doesn’t support all transaction types, and that you need a Ledger device to submit transactions from the Desktop Wallet.
+
+- Mobile Wallet: supports send GTU, shield GTU, and unshield GTU.
+- Desktop Wallet: supports all transaction types
+- Concordium Client: supports all transaction types
+
+How transactions work
+=====================
+
+When a baker receives a transaction from a participant on the chain, it performs a few basic checks to verify that the transaction is eligible for *inclusion* in a :ref:`block<glossary-block>`. Transactions that meet all checks are considered *successful* and their changes are applied to the chain. If any of the checks fail, the transaction is ignored. A transaction is permanent when the block that contains the transactions is :ref:`finalized<glossary-finalization>`.
+
+In some situations, transactions are included in the blockchain but recorded as *rejected*. This can happen, for example, if a sender tries to overdraw their account. If a transaction is rejected, the cost is still deducted from the sender account but other than that, it has no effect.
+
+There’s a :ref:`sequence number<glossary-transaction-sequence-number>` associated with each account. This number increases sequentially with each transaction sent from the account and is recorded into the transaction. If a transaction has a sequence number that doesn’t  match the current sequence number of the account, the transaction is not eligible for inclusion on the chain. This ensures that transactions are included only once and in a specific order.
+
+Transaction costs
+=================
+
+Every transaction has a well-defined *cost*, and the cost of each transaction depends on the transaction type. When the transaction is submitted to the chain, the cost is deducted from the sender's account and paid to the Concordium network as a fee for carrying out the transaction. Cost is measured in the unit NRG which corresponds to GTU according to a variable conversion factor (currently 1 NRG = 0.0001 GTU). Read more about conversions between GTU, NRG, and Euros in :ref:`exchange-rates`.

--- a/source/shared/net/concepts/concepts-transactions.rst
+++ b/source/shared/net/concepts/concepts-transactions.rst
@@ -8,7 +8,7 @@ Transactions overview
     :local:
     :backlinks: none
 
-A transaction on the Concordium blockchain is an operation which applies some change to the chain. All transactions are recorded on the chain and once recorded, they are immutable . A transaction always has one sender :ref:`account<glossary-account>` and is signed using the keys of this account.
+A transaction on the Concordium blockchain is an operation which applies some change to the chain. All transactions are recorded on the chain and once recorded, they are immutable. A transaction always has one sender :ref:`account<glossary-account>` and is signed using the keys of this account.
 
 The most basic transaction is the GTU transfer that is used to send GTU from one account to another. However, there are several transaction types on the Concordium blockchain:
 

--- a/source/shared/net/concepts/concepts-transactions.rst
+++ b/source/shared/net/concepts/concepts-transactions.rst
@@ -13,8 +13,10 @@ A transaction on the Concordium blockchain is an operation which applies some ch
 The most basic transaction is the GTU transfer that is used to send GTU from one account to another. However, there are several transaction types on the Concordium blockchain:
 
 - Send GTU
+- Send GTU with a schedule
 - Shield GTU
 - Unshield GTU
+- Make shielded transfer
 - Add baker
 - Remove baker
 - Update baker stake
@@ -37,7 +39,7 @@ In some situations, transactions are included in the blockchain but recorded as 
 
 There’s a :ref:`sequence number<glossary-transaction-sequence-number>` associated with each account. This number increases sequentially with each transaction sent from the account and is recorded into the transaction. If a transaction has a sequence number that doesn’t  match the current sequence number of the account, the transaction is not eligible for inclusion on the chain. This ensures that transactions are included only once and in a specific order.
 
-Transaction costs
+Transaction fees
 =================
 
-Every transaction has a well-defined *cost*, and the cost of each transaction depends on the transaction type. When the transaction is submitted to the chain, the cost is deducted from the sender's account and paid to the Concordium network as a fee for carrying out the transaction. Cost is measured in the unit NRG which corresponds to GTU according to a variable conversion factor (currently 1 NRG = 0.0001 GTU). Read more about conversions between GTU, NRG, and Euros in :ref:`exchange-rates`.
+Every transaction has a well-defined *fee*, and the fee of each transaction depends on the transaction type. When the transaction is submitted to the chain, the fee is deducted from the sender's account and paid to the Concordium network as a fee for carrying out the transaction. The fee is measured in the unit NRG which corresponds to GTU according to a variable conversion factor (currently 1 NRG = 0.0001 GTU). Read more about conversions between GTU, NRG, and Euros in :ref:`exchange-rates`.

--- a/source/shared/net/concepts/concepts-transactions.rst
+++ b/source/shared/net/concepts/concepts-transactions.rst
@@ -33,7 +33,7 @@ How transactions work
 
 When a baker receives a transaction from a participant on the chain, it performs a few basic checks to verify that the transaction is eligible for *inclusion* in a :ref:`block<glossary-block>`. Transactions that meet all checks are considered *successful* and their changes are applied to the chain. If any of the checks fail, the transaction is ignored. A transaction is permanent when the block that contains the transactions is :ref:`finalized<glossary-finalization>`.
 
-In some situations, transactions are included in the blockchain but recorded as *rejected*. This can happen, for example, if a sender tries to overdraw their account. If a transaction is rejected, the cost is still deducted from the sender account but other than that, it has no effect.
+In some situations, transactions are included in the blockchain but recorded as *rejected*. This can happen, for example, if a sender tries to overdraw their account. If a transaction is rejected, the transaction fee is still deducted from the sender account but other than that, it has no effect.
 
 There’s a :ref:`sequence number<glossary-transaction-sequence-number>` associated with each account. This number increases sequentially with each transaction sent from the account and is recorded into the transaction. If a transaction has a sequence number that doesn’t  match the current sequence number of the account, the transaction is not eligible for inclusion on the chain. This ensures that transactions are included only once and in a specific order.
 

--- a/source/shared/net/concepts/concepts-transactions.rst
+++ b/source/shared/net/concepts/concepts-transactions.rst
@@ -27,8 +27,8 @@ The most basic transaction is the GTU transfer that is used to send GTU from one
 You can make transactions using either the Desktop Wallet, the Mobile Wallet, or the Concordium Client. Note that the Mobile Wallet doesn’t support all transaction types, and that you need a Ledger device to submit transactions from the Desktop Wallet.
 
 - Mobile Wallet: supports send GTU, shield GTU, and unshield GTU.
-- Desktop Wallet: supports all transaction types
-- Concordium Client: supports all transaction types
+- Desktop Wallet: supports all transaction types (except smart contract transactions).
+- Concordium Client: supports all transaction types.
 
 How transactions work
 =====================

--- a/source/shared/net/desktop-wallet/shield-gtu-desktop.rst
+++ b/source/shared/net/desktop-wallet/shield-gtu-desktop.rst
@@ -30,3 +30,15 @@ If you have an account with GTU in the shielded balance, you can't add new crede
 #. Review the transaction on the Ledger and verify that the information matches the **Transaction details** in the Desktop Wallet. Navigate to the right and verify the sender address is correct. Continue navigating to the right and verify that the amount and the recipient address are correct.
 
 #. Press both buttons to sign the transaction. In the Desktop Wallet, you can see that the transfer has been submitted to the chain. Select **Finish**. When the transaction has been finalized, you can see the shielded balance on the account overview.
+
+.. _unshield-GTU:
+
+Unshield GTU
+============
+The steps to unshield GTU are similar to the ones to shield GTU.
+
+#. Select **Shielded Balance** on the relevant account, and then select **Unshield**.
+
+#. Enter the amount of GTU that you want to unshield, and then select **Continue**.
+
+#. Follow steps 4-7 as described above. When the transaction has been finalized, you can see that the shielded balance has changed, and you can see the the amount you unshielded in the **Transfers** list.

--- a/source/shared/net/references/transactions.rst
+++ b/source/shared/net/references/transactions.rst
@@ -2,66 +2,19 @@
 
 .. _transactions:
 
-============
-Transactions
-============
+==============================
+Concordium Client transactions
+==============================
 
 .. contents::
    :local:
    :backlinks: none
 
-A *transaction* is an operation which applies some change to the chain.
-Transactions always have one sender :ref:`account<glossary-account>` and are signed using the keys of
-this account.
 
-There are several transaction types: The most basic one is a GTU transfer, which
-moves tokens from the sender account to another account. Other transaction types
-include encrypted transfers, :ref:`adding a baker<become-a-baker>`, and updating keys of accounts
-and bakers.
+You can perform all types of transactions with the :ref:`concordium-client<concordium_client>`. To do so, you use specialized subcommands. For an introduction to transactions, see :ref:`Transactions overview <transactions-overview>`.
 
-Every transaction has a well-defined *cost*, the value of which depends on the
-transaction type as well as the payload in a way that reflects the computational
-effort of applying the transaction as closely as possible. When the transaction
-is submitted, its cost is deducted from the sender's account and paid to the
-network as a fee for carrying out the transaction. Cost is measured in the unit
-NRG which corresponds to GTU according to a variable conversion factor
-(currently 1 NRG = 0.0001 GTU). Read more about conversions between GTU, NRG, and Euros in :ref:`exchange-rates`.
-
-Once a baker receives a transaction from some client, it performs a few basic
-checks to verify that the transaction is eligible for *inclusion* in a :ref:`block<glossary-block>`.
-If any of these checks fail, the transaction is ignored. Included transactions
-which satisfy all further requirements are considered *successful* and have
-their changes applied to the chain. If something doesn't check out (for
-instance, the sender attempted to overdraw their account), the transaction is
-still included, but recorded as *rejected*. A rejected transaction has no effect
-other than deducting its cost from the sender.
-
-Each account has a :ref:`sequence number<glossary-transaction-sequence-number>` associated with it. This number increases
-sequentially with each transaction sent from this account and is recorded into
-the transaction. Transactions with sequence numbers that don't match the current
-one of the account are not considered eligible for inclusion on the chain. This
-ensures that transactions are included only once and in a specific order.
-
-Until some block containing a given transaction is :ref:`finalized<glossary-finalization>`, there is no
-guarantee that the transaction is permanent.
-
-Transfers (both plain and encrypted) can be performed using the Mobile Wallet.
-mobile app, or the :ref:`concordium-client<concordium_client>` tool. All other transaction types
-can only be done through ``concordium-client``.
-
-Mobile Wallet
-=============
-
-Once you create :ref:`an account<reference-id-accounts>` in the :ref:`wallet<guide-account-transactions>`, the **SEND** button brings you
-to the screen for doing transfers from the given account. Depending on whether
-you are in the public or shielded balance part of the account the transfer will
-be a plain transfer, or an encrypted transfer.
-
-Command-line tool
-=================
-
-All types of transactions can be performed using :ref:`concordium-client<concordium_client>`. The
-different transaction types are performed using specialized subcommands:
+Transaction commands
+====================
 
 +-------------------------------+-------------------------------------+
 | Command                       | Description                         |
@@ -95,54 +48,60 @@ different transaction types are performed using specialized subcommands:
 |                               | balance to public balance           |
 +-------------------------------+-------------------------------------+
 
-Each of these commands have a number of parameters specific to them, but share a
-common set of flags and configuration to control how they build transactions.
-Depending on the exact context, the flags are currently all optional:
+Each of these commands have a number of parameters specific to them, but share a common set of flags and configuration to control how they build transactions.
+
+Depending on the exact context, all flags are currently optional:
 
 -  ``--sender``: Name or address of the transaction's sender account.
-   The name is the one used when :ref:`importing the account<managing_accounts>` (assuming that this
+   The name is the one that's used when you :ref:`import the account<managing_accounts>` (assuming that this
    was done). Defaults to the account name "default".
+
 -  ``--keys``: A number of sign/verify key-pairs associated with the
    account, used to sign the transaction. The format is shown in the example
    below. Should be omitted if the account has been imported.
+
 -  ``--expiration``: Expiration time of the transaction given as a Unix
    epoch or duration string (e.g. ``5m`` for 5 minutes). Defaults to ``10m`` (10
    minutes).
+
 -  ``--energy``: Maximum amount of NRG to be spent on the transaction.
    With the currently supported transaction types, the default value is always
    the exact amount of energy needed.
+
 -  ``--nonce`` : Sequence number to use for the transaction. This is
    fetched automatically and should only be specified in special cases.
+
 -  ``--signers`` : Specification of which credential holders of the sender account that should sign the transaction, and which of their keys that should be used to sign. Example: ``--signers 0:1,0:2,3:0,3:1`` specifies that credential holder 0 signs with keys 1 and 2, while credential holder
    3 signs with keys 0 and 1. If the sender account is imported to the client, and ``--signers`` is not provided,
    ``concordium-client`` will sign with all keys in the local configuration of the account.
 
-
-In most cases, it should be sufficient to provide only the ``--sender`` option
+In most cases, you only need to provide the ``--sender`` option
 and use the account by name.
 
-In all cases, the command will display the exact parameters of the transaction
-before sending it, and ask the user to confirm that it matches their intent.
-Just before the transaction is sent the user is asked for the password to access
+In all cases, the command displays the exact parameters of the transaction
+before sending it, and you're asked to confirm that it matches your intent.
+Just before the transaction is sent, you're asked for the password to access
 the signing keys.
 
 Once a transaction has been submitted, the command will continuously poll and
 display its status until it's been :ref:`finalized<glossary-finalization>`.
 
-The commands for transferring GTU (both plain transfers and encrypted transfers)
-are described below.
+Commands for transferring GTU
+=============================
 
-The remaining commands are used to add, remove, and configure bakers. Their
-behavior is explained on the guide for :ref:`becoming a baker<become-a-baker>`.
+The commands for transferring GTU (both plain transfers and encrypted transfers)
+are described in the following table.
+
+The add, remove, and configure bakers commands are described in the topic :ref:`becoming a baker using the Concordium Client<become-a-baker>`.
 
 .. note::
 
-   For more information about a command, invoke it with the ``--help`` flag.
+   To see more information about a command, invoke it with the ``--help`` flag.
 
-Transfer
---------
+Transfer GTU
+------------
 
-A transfer is done using the following command:
+Use the following command for transfers:
 
 .. code-block:: console
 
@@ -150,8 +109,8 @@ A transfer is done using the following command:
 
 Apart from the generic transaction flags above, the parameters are:
 
--  ``--amount``: Number of GTU tokens to send.
--  ``--receiver``: Name or address of the receiver account.
+-  ``--amount``: number of GTU tokens to send.
+-  ``--receiver``: name or address of the receiver account.
 
 
 Example: Transferring 25 GTU from one account to another
@@ -169,8 +128,8 @@ to transfer 25 GTU is:
 
    $concordium-client transaction send-gtu --amount 25 --sender A --receiver B
 
-The output will look similar to the following (in the example we assume that the
-sender account A has three transaction signing keys 0, 1, 3).
+The output will look similar to the following. Note that in this example, we assume that the
+sender account A has three transaction signing keys 0, 1, and 3.
 
 .. code-block:: console
 
@@ -191,25 +150,25 @@ sender account A has three transaction signing keys 0, 1, 3).
    [13:05:27] Waiting for the transaction to be finalized...
    [13:05:27] Transaction finalized.
 
-Encrypted transfer
-------------------
+Make a shielded transfer
+------------------------
 
-An encrypted transfer is a transfer from a shielded balance to a shielded
-balance of another account. The command is very similar to a plain transfer
+A shielded transfer is a transfer from a shielded balance to a shielded
+balance of another account. The command is very similar to a standard  transfer.
 
 .. code-block:: console
 
    $concordium-client transaction send-gtu-encrypted --sender A --receiver B --amount 8
 
-This command will
+This command does the following:
 
--  query the chain for the shielded balance of account A from the
-   Concordium network
--  decrypt it
--  query the encryption key of account B from the Concordium network
--  and send the transaction.
+-  queries the chain for the shielded balance of account A from the
+   Concordium network.
+-  decrypts it.
+-  queries the encryption key of account B from the Concordium network
+-  sends the transaction.
 
-The interaction looks as follows.
+The interaction looks like the following:
 
 .. code-block:: console
 
@@ -234,10 +193,11 @@ The interaction looks as follows.
    [13:20:46] Transaction finalized.
 
 This command has all of the additional options of ``send-gtu``, as well as an
-additional flag ``--index.`` This flag, if given, is used to select which
+additional flag ``--index.`` If given, this flag is used to select which
 :ref:`incoming encrypted amounts<glossary-incoming-encrypted-amount>` that will be used as input to the transaction.
-This is best illustrated on an example. :ref:`Querying an account<query-account-state>` can display the
-list of incoming amounts on account. An output could look as follows
+
+This is illustrated with the following example. :ref:`Querying an account<query-account-state>` can display the
+list of incoming amounts on account. An output could look like this:
 
 .. code-block:: console
 
@@ -250,9 +210,9 @@ list of incoming amounts on account. An output could look as follows
      Self balance: c0000000000000000000...
    ...
 
-If we were to ``send-gtu-encrypted`` from the account while supplying index 8,
+If you want to ``send-gtu-encrypted`` from the account while supplying index 8,
 only the encrypted amount ``8c0faff6739bffc531c5...`` and the :ref:`self balance<glossary-self-balance>`
-would be used as input of the encrypted transfer.
+will be used as input of the encrypted transfer.
 
 If the supplied index is out of range ``concordium-client`` will refuse to send
 the transaction.
@@ -261,18 +221,15 @@ Shield an amount
 ----------------
 
 The command to shield an amount with ``concordium-client`` is ``account
-encrypt``. For example, an interaction to shield 10 GTU on account A looks as
-follows.
+encrypt``. For example, an interaction to shield 10 GTU on account A looks like the following
 
-The command is
+The command is:
 
 .. code-block:: console
 
    $concordium-client account encrypt --amount 10 --sender A
 
-It supports all of the same additional flags as the transfer transaction, apart
-from the ``--receiver`` since transfer from public to encrypted balance is
-always on the same account. The output looks as follows
+The command supports all of the same additional flags as the transfer transaction, except the ``--receiver`` since a transfer from a public to a shielded balance is always on the same account. The output looks like the following:
 
 .. code-block:: console
 
@@ -299,22 +256,22 @@ Unshield an amount
 
 The command to unshield an amount with ``concordium-client`` is
 ``account decrypt``. For example, an interaction to unshield 7 GTU on
-account B looks as follows.
+account B looks like the following:
 
-The command is
+The command is:
 
 .. code-block:: console
 
    $concordium-client account decrypt --sender B --amount 7
 
-This will
+This
 
--  query the state of account B from the Concordium network
--  decrypt the shielded balance and check that it is sufficient
--  send the transaction
+-  queries the state of account B from the Concordium network.
+-  decrypts the shielded balance and checks that there is sufficient funds.
+-  sends the transaction.
 
-This supports the same optional flags as ``encrypt``, with the addition
-of ``--index`` which has the same meaning as in the
+The command supports the same optional flags as ``encrypt`` with the addition
+of ``--index``, which has the same meaning as in the
 ``send-gtu-encrypted`` command.
 
 .. code-block:: console
@@ -339,44 +296,44 @@ of ``--index`` which has the same meaning as in the
 
 .. _transfer-with-a-schedule:
 
-Transfer with schedule
-----------------------
+Transfer GTU with a  schedule
+-----------------------------
 
-The command to send a transfer of GTU that will be released gradually over a
+The command to transfer GTU that will be released gradually according to a
 release schedule with ``concordium-client`` is ``transaction send-gtu-scheduled``.
-There are two ways of specifying the release schedule, either as regular intervals
-or as an explicit schedule at specific timestamps.
+There are two ways of specifying the release schedule, either as regular intervals or as an explicit schedule.
 
-When specifying the release schedule with regular intervals, the options ``--amount``
-, ``--every``, ``--for`` and ``--starting`` must be provided. For example, sending a transaction from A to B that will:
+-  Use a regular interval schedule to release an equal amount of GTU to a recipient at regular intervals.
 
-- release the same amount every day
+-  Use an explicit schedule if you want the intervals between releases to be of different lengths, or if you want to be able to release different amounts of GTU to the recipient at each interval.
+
+When you specify a release schedule with regular intervals, you must provide the options ``--amount``
+, ``--every``, ``--for`` and ``--starting``. For example, to send a transaction from A to B that:
+
+- releases the same amount every day
 - for 10 days in a row
 - for a total amount of 100 GTU
 - starting on the 10th of February 2021 at 12:00:00 UTC
 
-would be done with the following command:
+use the following command:
 
 .. code-block:: console
 
    $concordium-client transaction send-gtu-scheduled --amount 100 --every Day --for 10 --starting 2021-02-10T12:00:00Z --receiver B --sender A
 
-When specifying the release schedule explicitly, the option ``--schedule`` must be used
-which takes a comma-separated list of releases in the form of ``<amount> at <date>``. For example,
-sending a transaction from A to B that will:
+When you specify an explicit release schedule, you must use the option ``--schedule``, which takes a comma-separated list of releases in the form of ``<amount> at <date>``. For example, to send a transaction from A to B that:
 
-- release 100 on January 1st 2021 at 12:00:00 UTC
-- release 150 on February 15th 2021 at 12:00:00 UTC
-- release 200 on December 31st 2021 at 12:00:00 UTC
+- releases 100 on January 1st 2022 at 12:00:00 UTC
+- releases 150 on February 15th 2022 at 12:00:00 UTC
+- releases 200 on December 31st 2022 at 12:00:00 UTC
 
-would be done with the following command:
+Use the following command:
 
 .. code-block:: console
 
    $concordium-client transaction send-gtu-scheduled --schedule "100 at 2021-01-01T12:00:00Z, 150 at 2021-02-15T12:00:00Z, 200 at 2021-12-31T12:00:00Z" --receiver B --sender A
 
-Querying account information of the receiver account afterwards, will show the
-list of releases that are still pending to be released:
+If you query the account information of the recipient account afterwards, it will show the list of releases that are still pending to be released:
 
 .. code-block:: console
 
@@ -391,6 +348,6 @@ list of releases that are still pending to be released:
    Nonce:                 1
    ...
 
-The amount that is not yet released is also accounted in the ``Balance`` field
+The amount that is not yet released is also included in the ``Balance`` field
 so in this case the account owns ``100 GTU`` that don't belong to any pending
 release schedule.

--- a/source/shared/net/references/transactions.rst
+++ b/source/shared/net/references/transactions.rst
@@ -301,7 +301,7 @@ Transfer GTU with a  schedule
 
 The command to transfer GTU that will be released gradually according to a
 release schedule with ``concordium-client`` is ``transaction send-gtu-scheduled``.
-There are two ways of specifying the release schedule, either as regular intervals or as an explicit schedule.
+There are two ways of specifying the release schedule, either at regular intervals or as an explicit schedule.
 
 -  Use a regular interval schedule to release an equal amount of GTU to a recipient at regular intervals.
 

--- a/source/testnet/net/concepts/concepts-transactions.rst
+++ b/source/testnet/net/concepts/concepts-transactions.rst
@@ -1,0 +1,2 @@
+
+.. include:: /../shared/net/concepts/concepts-transactions.rst

--- a/source/testnet/net/index.rst
+++ b/source/testnet/net/index.rst
@@ -31,6 +31,7 @@
 
    concepts/id-accounts
    concepts/concepts-baker
+   concepts/concepts-transactions
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION

## Separate conceptual transaction information from Concordium Client reference.

## Changes
Removed conceptual information from Client transactions topic.
Created new topic: Transactions overview
Added Unshield procedure to Shield topic. Information was missing. 

