### PR TITLE
Fixed typo in linux node link

### DIFF
--- a/source/mainnet/_templates/index.html
+++ b/source/mainnet/_templates/index.html
@@ -68,7 +68,7 @@
                 <ul class="feature-box-list">
                     <li><a href="{{ pathto('../testnet/net/guides/run-node-windows') }}">Run a node on Windows</a></li>
                     <li><a href="{{ pathto('../testnet/net/guides/run-node-macos') }}">Run a node on Mac</a></li>
-                    <li><a href="{{ pathto('../testnet/net/guides/guides/run-node') }}">Run a node on Linux</a></li>
+                    <li><a href="{{ pathto('../testnet/net/guides/run-node') }}">Run a node on Linux</a></li>
                     <li><a href="{{ pathto('../testnet/net/guides/overview-baker-process') }}">Get an overview of the baker process</a></li>
                 </ul>
                 <h3>Smart Contracts</h3>


### PR DESCRIPTION
## Purpose

After fixing the testnet landing page links, the linux guide link turned out to still be broken because of a typo.

## Changes

Typo in Linux link is now fixed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
