### PR TITLE
Explain moving baker-credentials to accessible location

### DIFF
--- a/source/testnet/net/guides/run-node-macos.rst
+++ b/source/testnet/net/guides/run-node-macos.rst
@@ -169,7 +169,7 @@ and finally specify this location in the service file for the Concordium Node.
 
    (replacing ``/path/to/baker-credentials.json`` with the actual file path).
 
-#. Edit the service file as an administrator: ``/Library/Concordium
+#. Edit the service file as an administrator. The service file is found here: ``/Library/Concordium
    Node/LaunchDaemons/software.concordium.testnet.node.plist``
 
 #. In the *EnviromentVariables* section of the file add the following::

--- a/source/testnet/net/guides/run-node-macos.rst
+++ b/source/testnet/net/guides/run-node-macos.rst
@@ -158,18 +158,25 @@ Configure a node as a baker
 To run a node as baker, you first have to generate baker keys in the desktop
 wallet and then register the keys on an account. For more information, see,
 :ref:`Add a baker account in the Desktop Wallet<create-baker-desktop>`.
-You then have to change the service file for the Concordium Node.
+You then need to move the generated file to a location accessible by the node,
+and finally specify this location in the service file for the Concordium Node.
 
-#. Edit this file as an administrator: ``/Library/Concordium
+#. Move the ``baker-credentials.json`` file to the node's config folder:
+
+   .. code-block:: console
+
+      sudo cp "/path/to/baker-credentials.json" "/Library/Application Support/Concordium Node/Testnet/Config/baker-credentials.json"
+
+   (replacing ``/path/to/baker-credentials.json`` with the actual file path).
+
+#. Edit the service file as an administrator: ``/Library/Concordium
    Node/LaunchDaemons/software.concordium.testnet.node.plist``
+
 #. In the *EnviromentVariables* section of the file add the following::
 
     <!-- Path to the baker credentials file. -->
     <key>CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE</key>
-    <string>/full/path/to/baker-credentials.json</string>
-
-#. Replace ``/full/path/to/baker-credentials.json`` with the full path to the
-   baker credentials files.
+    <string>/Library/Application Support/Concordium Node/Testnet/Config/baker-credentials.json</string>
 
 #. Restart your node by running **Concordium Node Stop Testnet** (if running) and then
    **Concordium Node Start Testnet**.


### PR DESCRIPTION
## Purpose

Add a step explaining how to move the `baker-credentials.json` file to a location accessible by the mac node service (the config folder).
The mac node runs as a system service, so if you keep your `baker-credentials.json` file in e.g. a user's Downloads folder, then the service won't be able to read it and thus not able to run.

## Changes

Add an additional step in the baker section and minor changes to paths and phrasing.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.