### PR TITLE
Fixed a dashboard link in Run a node Ubuntu

### DIFF
--- a/source/testnet/net/guides/run-node-ubuntu.rst
+++ b/source/testnet/net/guides/run-node-ubuntu.rst
@@ -95,7 +95,7 @@ The services are also enabled to start automatically on system start.
 
 3. Enter a ``node name`` when prompted. The node name is visible on the network dashboard. When you have installed the services, the ``concordium-testnet-node`` will be running automatically.
 
-#. To verify that the node is running, go to the `Concordium dashboard <https://dashboard.testnet.concordium.software/>`__ and look for a node with the name you provided.
+#. To verify that the node is running, go to the `Concordium dashboard <https://dashboard.testnet.concordium.com/>`__ and look for a node with the name you provided.
 
 .. Note::
    If the node is installed fresh, you can speed up initial catchup by downloading a batch of blocks and using `Out of band catchup <https://github.com/Concordium/concordium-node/blob/main/scripts/distribution/ubuntu-packages/README.md#out-of-band-catchup>`__.


### PR DESCRIPTION
## Purpose

There was a dead link on the Run a Node on Ubuntu page.

## Changes

Link was fixed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
