### PR TITLE
added documentation for automatic updates (mainnet only)

### DIFF
--- a/source/mainnet/net/desktop-wallet/update-application.rst
+++ b/source/mainnet/net/desktop-wallet/update-application.rst
@@ -16,7 +16,7 @@ Automatic updates
 
 The Desktop Wallet notifies you when an update is available, and you then have the following options:
 
-* **Restart and Install** to install the update, or
+* **Restart and Install** to install the update
 * **Remind me** to be notified again the next time you open the application.
 
 If you choose to update the application, the update process will automatically ensure the integrity of the downloaded files before applying the update.

--- a/source/mainnet/net/desktop-wallet/update-application.rst
+++ b/source/mainnet/net/desktop-wallet/update-application.rst
@@ -19,7 +19,7 @@ The Desktop Wallet notifies you when an update is available, and you then have t
 * **Restart and Install** to install the update
 * **Remind me** to be notified again the next time you open the application.
 
-If you choose to update the application, the update process will automatically ensure the integrity of the downloaded files before applying the update.
+If you choose to update the application, the update process automatically ensures the integrity of the downloaded files before applying the update.
 
 .. note::
     If the integrity of an update cannot be verified, the update is rejected. The verification step is there to make sure the update is an official release from Concordium, and has not been tampered with by malware.

--- a/source/mainnet/net/desktop-wallet/update-application.rst
+++ b/source/mainnet/net/desktop-wallet/update-application.rst
@@ -9,7 +9,7 @@ Updating the desktop wallet
     :backlinks: none
     :depth: 1
 
-The desktop wallet application will automatically update itself on **MacOS**, **Windows**, and **Linux** (though only for the AppImage distribution).
+The Desktop Wallet installs updates automatically on **MacOS**, **Windows**, and **Linux** (though only for the AppImage distribution).
 
 Automatic updates
 =================

--- a/source/mainnet/net/desktop-wallet/update-application.rst
+++ b/source/mainnet/net/desktop-wallet/update-application.rst
@@ -1,0 +1,30 @@
+.. _update-application:
+
+===========================
+Updating the desktop wallet
+===========================
+
+.. contents::
+    :local:
+    :backlinks: none
+    :depth: 1
+
+The desktop wallet application will automatically update itself on **MacOS**, **Windows**, and **Linux** (though only for the AppImage distribution).
+
+Automatic updates
+=================
+
+When notified about an update being available, you can select either:
+
+* **Restart and Install** to install the update, or
+* **Remind me** to be notified again the next time you open the application.
+
+If you choose to update the application, the update process will automatically ensure the integrity of the downloaded files before applying the update.
+
+.. note::
+    If the integrity of an update cannot be verified, the update is rejected. The verification step is there to make sure the update is an official release from Concordium, and has not been tampered with by malware.
+
+Manually updating
+=================
+
+To manually update the desktop wallet, simply go to the :ref:`downloads page<downloads-desktop-wallet>`, to download the latest version.

--- a/source/mainnet/net/desktop-wallet/update-application.rst
+++ b/source/mainnet/net/desktop-wallet/update-application.rst
@@ -14,7 +14,7 @@ The Desktop Wallet installs updates automatically on **MacOS**, **Windows**, and
 Automatic updates
 =================
 
-When notified about an update being available, you can select either:
+The Desktop Wallet notifies you when an update is available, and you then have the following options:
 
 * **Restart and Install** to install the update, or
 * **Remind me** to be notified again the next time you open the application.

--- a/source/mainnet/net/desktop-wallet/update-application.rst
+++ b/source/mainnet/net/desktop-wallet/update-application.rst
@@ -27,4 +27,4 @@ If you choose to update the application, the update process automatically ensure
 Manually updating
 =================
 
-To manually update the desktop wallet, simply go to the :ref:`downloads page<downloads-desktop-wallet>`, to download the latest version.
+To manually update the desktop wallet, go to the :ref:`downloads page<downloads-desktop-wallet>` and download the latest version.

--- a/source/mainnet/net/desktop-wallet/update-application.rst
+++ b/source/mainnet/net/desktop-wallet/update-application.rst
@@ -1,7 +1,7 @@
 .. _update-application:
 
 ===========================
-Updating the desktop wallet
+Update the desktop wallet
 ===========================
 
 .. contents::

--- a/source/mainnet/net/index.rst
+++ b/source/mainnet/net/index.rst
@@ -47,6 +47,7 @@
 
    desktop-wallet/install-ledger-app
    desktop-wallet/get-started-desktop
+   desktop-wallet/update-application
    desktop-wallet/create-identity-desktop
    desktop-wallet/create-account-desktop
    desktop-wallet/accounts-desktop

--- a/source/mainnet/net/installation/downloads.rst
+++ b/source/mainnet/net/installation/downloads.rst
@@ -33,6 +33,7 @@ The Concordium Mobile Wallet has been verified by NowSecure.
       :target: https://www.nowsecure.com/certified-apps/concordium/
 
 
+.. _downloads-desktop-wallet:
 
 Concordium Desktop Wallet
 =========================


### PR DESCRIPTION
## Purpose

From DTW version 1.2 and onwards, the application features automatic updates. This PR ensures our documentation describes how this works, and what to do (manually updating) if this is not supported. 

## Changes

- Added page describing both automatic and manual update process

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

Closes #232 
