### PR TITLE
Build a simple 404 page from mainnet documentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ six==1.16.0
 snowballstemmer==2.1.0
 Sphinx==4.0.1
 sphinx-autobuild==2021.3.14
+sphinx-notfound-page==0.7.1
 sphinx-rtd-theme==0.5.2
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -34,6 +34,9 @@ cp -r CLAs "${build_dir}/CLAs"
 printf "Copying 'extra' directory to ${build_dir}\n"
 cp -r extra "${build_dir}/extra"
 
+printf "Adding symlink ${build_dir}/404.html to ${languages[0]}/${versions[0]}/404.html\n"
+ln -sf "${languages[0]}/${versions[0]}/404.html" "${build_dir}/404.html"
+
 for current_version in ${versions[@]}; do
   printf "\nVersion '${current_version}':\n-----------------------------\n"
   export current_version
@@ -44,3 +47,4 @@ for current_version in ${versions[@]}; do
     sphinx-build "${source_dir}/${current_version}" "${build_dir}/${current_language}/${current_version}" -D language="${current_language}" -W
   done
 done
+

--- a/source/mainnet/conf.py
+++ b/source/mainnet/conf.py
@@ -47,6 +47,7 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinx.ext.intersphinx",
     # "sphinx.ext.imgconverter", # To support svg when targeting LaTeX
+    'notfound.extension',
     "multidoc"
 ]
 
@@ -67,6 +68,8 @@ graphviz_dot_args=[
     "-Efontsize=12",
 ]
 
+# Disable default url prefix "/en/latest/" on every resource.
+notfound_urls_prefix = "/"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates', '../shared/_templates']


### PR DESCRIPTION
## Purpose

Closes #134.

## Changes

- Generate 404.html page from mainnet documentation
- Build script symlinks this file to the build root (required by Github Pages)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

