### PR TITLE
Fixed links on landing page

### DIFF
--- a/source/mainnet/_templates/index.html
+++ b/source/mainnet/_templates/index.html
@@ -42,10 +42,10 @@
                 </ul>
                 <h3>Participate in the network</h3>
                 <ul class="feature-box-list">
-                    <li><a href="{{ pathto('/net/guides/run-node-windows') }}">Run a node on Windows</a></li>
-                    <li><a href="{{ pathto('/net/guides/run-node-macos') }}">Run a node on Mac</a></li>
-                    <li><a href="{{ pathto('/net/guides/run-node') }}">Run a node on Linux</a></li>
-                    <li><a href="{{ pathto('/net/guides/overview-baker-process') }}">Get an overview of the baker process</a></li>
+                    <li><a href="{{ pathto('net/guides/run-node-windows') }}">Run a node on Windows</a></li>
+                    <li><a href="{{ pathto('net/guides/run-node-macos') }}">Run a node on Mac</a></li>
+                    <li><a href="{{ pathto('net/guides/run-node') }}">Run a node on Linux</a></li>
+                    <li><a href="{{ pathto('net/guides/overview-baker-process') }}">Get an overview of the baker process</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Purpose

The "run a node links" on the landing page for Mainnet had a / too much, causing the links to not work.

## Changes

Removed the /'s.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance


By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
