### PR TITLE
Allow toctrees to be hidden in sidebar

### DIFF
--- a/source/exts/multidoc.py
+++ b/source/exts/multidoc.py
@@ -49,10 +49,13 @@ def html_page_context(app, pagename, templatename, context, doctree):
                 collapse = collapse,
                 includehidden = includehidden,
                 titles_only = titles_only)
-            if result == None:
-                result = toc
-            else:
-                result.extend(toc)
+            # Ensure the table of content is not hidden
+            if toc is not None:
+                # Append the table of content to be rendered
+                if result == None:
+                    result = toc
+                else:
+                    result.extend(toc)
         env.resolve_references(result, pagename, app.builder)
         return app.builder.render_partial(result)['fragment']
 

--- a/source/mainnet/conf.py
+++ b/source/mainnet/conf.py
@@ -125,7 +125,7 @@ html_theme_options = {
     # 'collapse_navigation': False,
     # 'sticky_navigation': True,
     'navigation_depth': 2,
-    # 'includehidden': False,s
+    'includehidden': False,
     # 'titles_only': False
 }
 

--- a/source/testnet/conf.py
+++ b/source/testnet/conf.py
@@ -125,7 +125,7 @@ html_theme_options = {
     # 'collapse_navigation': False,
     # 'sticky_navigation': True,
     'navigation_depth': 2,
-    # 'includehidden': False,s
+    'includehidden': False,
     # 'titles_only': False
 }
 


### PR DESCRIPTION
## Purpose

We sometimes want to include RST files which are not included in the toctree.

## Changes

- Set ReadTheDocs setting for allowing the toctree to be hidden.
- Fix bug with custom extension which flattens the toctree on level.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
