### PR TITLE
Updated dead links after MW doc update

### DIFF
--- a/source/mainnet/_templates/index.html
+++ b/source/mainnet/_templates/index.html
@@ -32,12 +32,12 @@
                 <ul class="feature-box-list">
                     <li><a href="{{ pathto('net/installation/downloads') }}">Download a wallet</a></li>
                     <li><a href="{{ pathto('net/desktop-wallet/create-identity-desktop') }}">Create your first account using <br> the Desktop Wallet</a></li>
-                    <li><a href="{{ pathto('net/mobile-wallet/get-started') }}">Create your first account using <br> the Mobile Wallet</a></li>
+                    <li><a href="{{ pathto('net/mobile-wallet/create-identity') }}">Create your first account using <br> the Mobile Wallet</a></li>
                     <li><a href="{{ pathto('net/desktop-wallet/install-ledger-app') }}">Setup a Ledger Nano S for <br> the Desktop Wallet</a></li>
                 </ul>
                 <h3>Make a transfer</h3>
                 <ul class="feature-box-list">
-                    <li><a href="{{ pathto('net/mobile-wallet/accounts-transactions') }}">Make a transfer with the mobile wallet</a></li>
+                    <li><a href="{{ pathto('net/mobile-wallet/make-simple-transfer-mw') }}">Make a transfer with the mobile wallet</a></li>
                     <li><a href="{{ pathto('net/desktop-wallet/send-gtu-single-desktop') }}">Make a transfer with the desktop wallet</a></li>
                 </ul>
                 <h3>Participate in the network</h3>
@@ -61,12 +61,12 @@
                 <ul class="feature-box-list">
                     <li><a href="{{ pathto('../testnet/net/installation/downloads') }}">Download a wallet</a></li>
                     <li><a href="{{ pathto('../testnet/net/desktop-wallet/create-identity-desktop') }}">Create your first account using <br> the Desktop Wallet</a></li>
-                    <li><a href="{{ pathto('../testnet/net/mobile-wallet/get-started') }}">Create your first account using <br> the Mobile Wallet</a></li>
+                    <li><a href="{{ pathto('../testnet/net/mobile-wallet/create-identity') }}">Create your first account using <br> the Mobile Wallet</a></li>
                     <li><a href="{{ pathto('../testnet/net/desktop-wallet/install-ledger-app') }}">Setup a Ledger Nano S for <br> the Desktop Wallet</a></li>
                 </ul>
                 <h3>Make a transfer</h3>
                 <ul class="feature-box-list">
-                    <li><a href="{{ pathto('../testnet/net/mobile-wallet/accounts-transactions') }}">Make a transfer with the mobile wallet</a></li>
+                    <li><a href="{{ pathto('../testnet/net/mobile-wallet/make-simple-transfer-mw') }}">Make a transfer with the mobile wallet</a></li>
                     <li><a href="{{ pathto('../testnet/net/desktop-wallet/send-gtu-single-desktop') }}">Make a transfer with the desktop wallet</a></li>
                 </ul>
                 <h3>Participate in the network</h3>

--- a/source/shared/net/concepts/id-accounts.rst
+++ b/source/shared/net/concepts/id-accounts.rst
@@ -46,7 +46,7 @@ a number of public and private keys, a signature from the identity provider, as
 well as a number of secret values the user must use to be able to use the
 identity to create accounts.
 
-You can create identities in the :ref:`Desktop Wallet <create-initial-account-desktop>` or in the :ref:`Mobile Wallet <mobile-get-started>`. The |Net| release presently supports the Notabene identity issuance flow.
+You can create identities in the :ref:`Desktop Wallet <create-initial-account-desktop>` or in the :ref:`Mobile Wallet <create-identity>`. The |Net| release presently supports the Notabene identity issuance flow.
 
 .. Warning::
    Currently, it is not possible to exchange identities and accounts between the Mobile Wallet and the Desktop Wallet. If you try to import a file that has been exported from the Mobile Wallet into the Desktop Wallet, the import will fail, and likewise, if you try to import a file exported from the Desktop Wallet into the Mobile Wallet.

--- a/source/shared/net/guides/become-baker.rst
+++ b/source/shared/net/guides/become-baker.rst
@@ -43,7 +43,7 @@ Import the account
 
 This section provides a brief description of how to import an account using the Concordium Client. For a complete description, see :ref:`managing_accounts`.
 
-You can only import accounts created in the Mobile Wallet into the Concordium Client. That is, you cannot import accounts created in the Desktop Wallet because they are created using a Ledger device. You get the account information by exporting a JSON file with the account information from the Mobile Wallet. For more information, see  :ref:`Explore the *More* page in the Mobile Wallet <explore-more>`.
+You can only import accounts created in the Mobile Wallet into the Concordium Client. That is, you cannot import accounts created in the Desktop Wallet because they are created using a Ledger device. You get the account information by exporting a JSON file with the account information from the Mobile Wallet. For more information, see  :ref:`Export or import your identities and accounts <export-import-mw>`.
 
 To import an account run:
 

--- a/source/shared/net/guides/deciding-wallet.rst
+++ b/source/shared/net/guides/deciding-wallet.rst
@@ -52,7 +52,7 @@ We strongly recommend that you make a backup of your wallet regardless of which 
 
 - **Backup of the Desktop Wallet**: You create a backup of your accounts, identities, and addresses by exporting them to a file from the Desktop Wallet. This doesn't mean that you create a backup of your private keys. The backup of your private keys is essentially the 24-word recovery phrase for the Ledger. So for a complete backup, you need both the exported file and the Ledger. If you lose the PIN code to the Ledger, you can restore the Ledger device from your recovery phrase. You can also set up a new Ledger device with the recovery phrase. It's vital that you keep the recovery phrase safe. For more information, see :ref:`Make a backup of identities, accounts, and addresses<export-import-desktop>` and :ref:`Account recovery<account-recovery-desktop>`.
 
-- **Backup of the Mobile Wallet**: You create a backup of your accounts, identities, addresses, and private keys by exporting them to a file from the Mobile Wallet. If you lose your phone or upgrade to a new phone, you can use the file to gain access to your accounts and identities. It's vital that you keep the password to the backup file safe. Anyone with access to the file can gain access to your crypto assets. For more information, see :ref:`Explore the *More* page in the Mobile Wallet <explore-more>`.
+- **Backup of the Mobile Wallet**: You create a backup of your accounts, identities, addresses, and private keys by exporting them to a file from the Mobile Wallet. If you lose your phone or upgrade to a new phone, you can use the file to gain access to your accounts and identities. It's vital that you keep the password to the backup file safe. Anyone with access to the file can gain access to your crypto assets. For more information, see :ref:`Export or import your identities and accounts <export-import-mw>`.
 
 .. Warning::
    You are solely responsible for keeping your assets secure regardless of which wallet you choose to use. You must never share your private keys, PIN codes, passwords, recovery phrases, Ledgers, or mobile devices with anyone.
@@ -99,6 +99,6 @@ Next steps
 
 If you want to use the Desktop Wallet, :ref:`download <downloads>` and install it on your computer, and then see :ref:`Overview of setting up the Desktop Wallet<overview-desktop>` for the next steps.
 
-If you want to use the Mobile Wallet, :ref:`download <downloads>` the app on your mobile phone, and then see :ref:`Get started with the Mobile Wallet<mobile-get-started>` for the next steps.
+If you want to use the Mobile Wallet, :ref:`download <downloads>` the app on your mobile phone, and then see :ref:`Set up the Mobile Wallet<setup-mobile-wallet>` for the next steps.
 
 If you want to learn more about the Ledger device, go to `Ledger's website <https://www.ledger.com>`_.

--- a/source/testnet/net/resources/release-notes.rst
+++ b/source/testnet/net/resources/release-notes.rst
@@ -342,7 +342,7 @@ October 6th, 2020.
 -  µGTU. The smallest unit has been changed from 10-4 to 10-6.
 -  Bulletproofs. The core blockchain has been updated to support use of
    bulletproofs.
--  :ref:`Encrypted(shielded) amounts and transfers <move-an-amount-to-the-shielded-balance>`. Support for shielded
+-  :ref:`Encrypted(shielded) amounts and transfers <make-shielded-transfer-mw>`. Support for shielded
    transactions has been added to the core blockchain. Support for
    sending and receiving shielded amounts are added to the mobile apps
    and the Concordium client.


### PR DESCRIPTION
## Purpose

Some of the links on the landing page died after updating the mobile wallet docs, and some old labels also had to be updated.

## Changes

Updated links and labels.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
