### PR TITLE
Added concordium-client v3-0-4 to release notes - don't merge before enterprise identities release

### DIFF
--- a/source/mainnet/net/resources/release-notes-mainnet.rst
+++ b/source/mainnet/net/resources/release-notes-mainnet.rst
@@ -8,6 +8,36 @@ Release notes
    :local:
    :backlinks: none
 
+Mainnet 3: Alpha Centauri 3.0
+==============================
+
+December 10, 2021
+
+Concordium Client v3.0.4
+------------------------
+
+- Credentials revealing the newly introduced attribute LEI can be deployed.
+- Renamed GTU token to CCD.
+- Renamed ``send-gtu``, ``send-gtu-scheduled`` and ``send-gtu-encrypted`` to ``send``, ``send-scheduled`` and ``send-shielded``.
+- Renamed ``account encrypt``/``decrypt`` to ``account shield``/``unshield``.
+- Added command for generating aliases of an address.
+- Now shows line breaks, tabs etc. in memo transfers (when it's CBOR encoded string), instead of escaping them as ``\n``, ``\t`` etc.
+- Now displays memo as JSON in a more readable way.
+- Added time units to slot duration and epoch duration in consensus status.
+- Updated the ``register-data`` command to register data as CBOR encoded strings or JSON using the new flags ``--string`` and ``--json``. Raw data can still be registered using the new flag ``--raw``.
+- Added ``raw DisconnectPeer``, a counterpart to the existing ``raw ConnectPeer``.
+- Now warning  the user when trying to add a baker with a stake below the minimum threshold.
+- Improved how contract schemas are shown as JSON:
+
+   - Now displays complex types in arrays correctly.
+   - Use angle brackets to indicate placeholders, e.g. ``"<UInt16>"`` instead of ``"UInt16"``.
+- Improved ``module inspect``:
+
+   - Now shows all contracts from a module regardless of whether a schema is included or not.
+   - Now shows the receive methods for contracts as well.
+- Now allows sending transactions where the sender is an account alias.
+
+
 Mainnet 2: Alpha Centauri 2.1
 =============================
 


### PR DESCRIPTION
## Purpose

Copy&paste of testnet release of concordium-client v3.0.4 to mainnet release notes.

## Changes

Added conccordium-client v3.0.4.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

