### PR TITLE
checksums on enterprise downloads

### DIFF
--- a/source/mainnet/net/guides/enterprise-identities.rst
+++ b/source/mainnet/net/guides/enterprise-identities.rst
@@ -22,10 +22,13 @@ Create an enterprise identity
 #. Download the ``enterprise-identities`` tools for your platform.
 
    - `Tools for Linux <https://distribution.concordium.software/tools/linux/enterprise-identities.tar.gz>`_
+      - SHA256 checksum of the download: ``b9981c542f46e92dd05e8b3e9bf46684e9de364bd331cd6fa8db98ed99b4df84``
 
    - `Tools for Windows <https://distribution.concordium.software/tools/windows/signed/enterprise-identities.zip>`_
+      - SHA256 checksum of the download: ``4a13eec29b6c7fc8214555c6b13e431c20df449bfd11e1a2f26b6a6e91a03957``
 
    - `Tools for MacOS <https://distribution.concordium.software/tools/macos/signed/enterprise-identities.zip>`_
+      - SHA256 checksum of the download: ``242a0ff19f84c91ec0c1a3c7696718eee61f144a73a3700d8969f3531384ad6e``
 
 #. Extract the files in the bundle to the same location on your computer. The bundle contains the following files:
 
@@ -40,10 +43,13 @@ Create an enterprise identity
 #. Download ``concordium-client`` for your platform.
 
    - `Linux <https://distribution.concordium.software/tools/linux/concordium-client_3.0.4-0>`_
+      - SHA256 checksum of the download: ``6ea2674ebae5dafd9de3c730db536fc0675627b6b867f05a944a1a60dd5ceca8``
 
    - `Windows <https://distribution.concordium.software/tools/windows/signed/concordium-client_3.0.4-0.exe>`_
+      - SHA256 checksum of the download: ``f6cafdd472b02ead818cc0f463a4cf40053dda33a824a2dfed816744a48a579c``
 
    - `MacOS <https://distribution.concordium.software/tools/macos/signed/concordium-client_3.0.4-0.zip>`_
+      - SHA256 checksum of the download: ``3173cbe28373d9a787978b236aefdaa20d129496b61e545ed7369d8922e10d05``
 
 
 #. To generate a request for an identity object, follow the `generate request instructions <https://github.com/Concordium/concordium-base/blob/main/rust-bins/docs/user-cli.md#generate-a-request-for-the-identity-objectinstructions>`_. Email the ``request.json`` output file to ania@notabene.id. Store the auxiliary output securely.


### PR DESCRIPTION
## Purpose

Exchanges are asking for hashes on the downloads for enterprise identities

## Changes

- Added sha256 checksums for the linked files on enterprise identities page.
