### PR TITLE
Updated release notes for mainnet and testnet

### DIFF
--- a/source/mainnet/net/installation/downloads.rst
+++ b/source/mainnet/net/installation/downloads.rst
@@ -70,14 +70,14 @@ Concordium Client
 =================
 Download the Concordium Client:
 
--  `Download the Concordium Client for Linux <https://distribution.concordium.software/tools/linux/concordium-client_1.1.1-0>`_
+-  `Download the Concordium Client for Linux <https://distribution.concordium.software/tools/linux/concordium-client_3.0.4-0>`_
 
    - SHA256 checksum of the download: :substitution-code:`|client-linux-checksum|`
    - :ref:`Verification instructions <verification-client-linux>`
 
--  `Download the Concordium Client for macOS <https://distribution.concordium.software/tools/macos/signed/concordium-client_1.1.1-0.zip>`_.
+-  `Download the Concordium Client for macOS <https://distribution.concordium.software/tools/macos/signed/concordium-client_3.0.4-0.zip>`_.
 
--  `Download the Concordium Client for Windows <https://distribution.concordium.software/tools/windows/signed/concordium-client_1.1.1-0.exe>`_
+-  `Download the Concordium Client for Windows <https://distribution.concordium.software/tools/windows/signed/concordium-client_3.0.4-0.exe>`_
 
 
 Cargo-concordium

--- a/source/mainnet/net/installation/downloads.rst
+++ b/source/mainnet/net/installation/downloads.rst
@@ -100,7 +100,7 @@ Node Debian package
 -------------------
 To run a node on a server with Ubuntu, you need a Debian package.
 
-- `Download the Debian package <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_1.1.3_amd64.deb>`_
+- `Download the Debian package <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_3.0.0_amd64.deb>`_
 
    - SHA256 checksum of the download: :substitution-code:`|node-deb-package-checksum|`
    - :ref:`Verification instructions <verification-node-debian-package>`
@@ -113,9 +113,9 @@ Full suite for running a node on Linux using Docker
 ---------------------------------------------------
 Download the full suite for running a node on Linux using Docker. The suite contains Concordium Node, Concordium Client and cargo-concordium.
 
-- `Download the suite for Linux <https://distribution.mainnet.concordium.software/tools/linux/concordium-software-linux-1.1.3-0-mainnet.tar.gz>`_
+- `Download the suite for Linux <https://distribution.mainnet.concordium.software/tools/linux/concordium-software-linux-3.0.0-0-mainnet.tar.gz>`_
 
-   - SHA256 checksum of the download: ``1e86ceda79be5bcb84f2615fdcd494fc7bc6e50f5e65c35cf47262e126c3be55``
+   - SHA256 checksum of the download: ``897ef39807eb449945b0498def00ca14d2762be8f9d206a62f1d9cd97f2beec0``
 
 To learn how to run a node with Docker, see :ref:`Run a node with Docker <run-a-node>`.
 
@@ -124,7 +124,7 @@ Native Windows node
 
 To run a node on Windows, you need a Windows Installer package.
 
-- `Download the Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-1.1.3.msi>`_
+- `Download the Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-3.0.0.msi>`_
 
 To learn how to run a node on Windows, see :ref:`Run and manage a node on Windows <run-node-windows>`
 
@@ -133,7 +133,7 @@ Native Mac node
 
 To run a node on macOS, you need a macOS installer package.
 
-- `Download the macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-1.1.3.pkg>`_
+- `Download the macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-3.0.0.pkg>`_
 
 To learn how to run a node on Mac, see :ref:`Run and manage a node on macOS  <run-node-macos>`.
 

--- a/source/mainnet/net/resources/release-notes-mainnet.rst
+++ b/source/mainnet/net/resources/release-notes-mainnet.rst
@@ -26,6 +26,22 @@ Concordium Desktop Wallet v1.3.0
 - Finalized transactions are no longer stored in the local database, but are instead always fetched from the wallet proxy when needed.
 - Failed database migrations errors are now shown correctly to the user.
 
+Concordrium Node v3.0.0
+-----------------------
+
+- Introduced support for account aliases via protocol P3. Accounts can be queried in ``GetAccountInfo``, ``GetAccountNonFinalizedTransactions``, ``GetNextAccountNonce`` by any alias.
+- ``GetAccountInfo`` object now has an additional field ``accountAddress`` that contains the canonical address of the account.
+- Fixed a bug due to incorrect use of LMDB database environments, where a node would crash if queried at specific times.
+- Faster state queries by avoiding locking the block state file when reading.
+- Fixed a bug caused by shutting down RPC before the node, which caused the node to crash when attempting a graceful shutdown while processing RPC requests.
+- The node now drops all connections on an unrecognized protocol update and refuses to accept new transactions.
+
+Concordium Mobile Wallet for Android v1.0.22
+--------------------------------------------
+
+- Changed naming from GTU to CCD.
+- Various bug fixes
+
 December 13, 2021
 
 Concordium Ledger App v2.0.3

--- a/source/mainnet/variables.rst
+++ b/source/mainnet/variables.rst
@@ -9,12 +9,12 @@
 .. |cdw-rpm-checksum| replace:: a8b348c0141f39c50364436718107b8da17ce106ea32d0b0602d96c650ee9277
 
 .. Client verification variables
-.. |client-linux| replace:: concordium-client_1.1.1-0
-.. |client-linux-checksum| replace:: 9753fbcea64a59b8a883a867524b089696a56a9bd5b0a0af95ada3d191ca1cc1
+.. |client-linux| replace:: concordium-client_3.0.4-0
+.. |client-linux-checksum| replace:: 6ea2674ebae5dafd9de3c730db536fc0675627b6b867f05a944a1a60dd5ceca8
 
 .. Node debian package verification variables
-.. |node-deb-package| replace:: concordium-node_1.1.3_amd64.deb
-.. |node-deb-package-checksum| replace:: 76254c341e1db5f3ee21d2058ec6802685bd5d0aaa3b3f5fd2a9cccdc63ddec4
+.. |node-deb-package| replace:: concordium-mainnet-node_3.0.0_amd64.deb
+.. |node-deb-package-checksum| replace:: 5f9acd862974be1c31c0b7a61aee5536146b3b45a9b492014d21a3a62c3bbfb3
 
 .. Mainnet genesis block verification variables
 .. |mainnet-genesis-block| replace:: genesis.dat

--- a/source/testnet/net/installation/downloads.rst
+++ b/source/testnet/net/installation/downloads.rst
@@ -26,7 +26,7 @@ iOS
 Android
 -------
 
-- `Download the Android version of Concordium Mobile Wallet for Testnet <http://distribution.testnet.concordium.com/tools/android/concordium-mobile-wallet_1.0.16(55).apk>`_
+- `Download the Android version of Concordium Mobile Wallet for Testnet <http://distribution.testnet.concordium.com/tools/android/concordium-mobile-wallet_1.0.22(61).apk>`_
 
 
 Concordium Desktop Wallet

--- a/source/testnet/net/resources/release-notes.rst
+++ b/source/testnet/net/resources/release-notes.rst
@@ -25,6 +25,12 @@ Concordium Desktop Wallet v1.3.0
 - Finalized transactions are no longer stored in the local database, but are instead always fetched from the wallet proxy when needed.
 - Failed database migrations errors are now shown correctly to the user.
 
+Concordium Mobile Wallet for Android v1.0.22
+--------------------------------------------
+
+- Changed naming from GTU to CCD.
+- Various bug fixes
+
 December 13, 2021
 
 Concordium Ledger App v2.0.3


### PR DESCRIPTION
## Purpose

To prepare for release on 17 December, updated release notes are needed.

## Changes

Updated mainnet release notes with node 3.0.0 information and android app version info. Updated testnet release notes with android app version info.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X ] I accept the above linked CLA.
