### PR TITLE
Updated conf.py for mainnet and testnet to enable conditional text

### DIFF
--- a/source/mainnet/conf.py
+++ b/source/mainnet/conf.py
@@ -284,4 +284,3 @@ redirects = {
 
 # -- Tags that enables the .. only option ----------------
 tags.add('mainnet')
-}

--- a/source/mainnet/conf.py
+++ b/source/mainnet/conf.py
@@ -281,3 +281,7 @@ redirects = {
     "./net/desktop-wallet/send-gtu-single-desktop": "/en/mainnet/net/desktop-wallet/send-ccd-single-desktop.html",
     "./net/desktop-wallet/shield-gtu-desktop": "/en/mainnet/net/desktop-wallet/shield-ccd-desktop.html",
 }
+
+# -- Tags that enables the .. only option ----------------
+tags.add('mainnet')
+}

--- a/source/testnet/conf.py
+++ b/source/testnet/conf.py
@@ -278,4 +278,3 @@ redirects = {
 
 # -- Tags that enables the .. only option ----------------
 tags.add('testnet')
-}

--- a/source/testnet/conf.py
+++ b/source/testnet/conf.py
@@ -275,3 +275,7 @@ redirects = {
     "./net/desktop-wallet/send-gtu-single-desktop": "/en/testnet/net/desktop-wallet/send-ccd-single-desktop.html",
     "./net/desktop-wallet/shield-gtu-desktop": "/en/testnet/net/desktop-wallet/shield-ccd-desktop.html",
 }
+
+# -- Tags that enables the .. only option ----------------
+tags.add('testnet')
+}


### PR DESCRIPTION
## Purpose

To enable conditional text in Sphinx and allow for more single sourcing of content.

## Changes

Added section at end of each conf.py file to enable tags so that the built in only function works.

