### PR TITLE
Updated glossary to remove GTU, add CCD.

### DIFF
--- a/source/mainnet/_templates/index.html
+++ b/source/mainnet/_templates/index.html
@@ -57,6 +57,12 @@
                     <li><a href="{{ pathto('net/guides/run-node-ubuntu') }}">Run a node on Ubuntu</a></li>
                     <li><a href="{{ pathto('net/guides/overview-baker-process') }}">Get an overview of the baker process</a></li>
                 </ul>
+                <h3>Smart Contracts</h3>
+                <ul class="feature-box-list">
+                    <li><a href="{{ pathto('smart-contracts/general/introduction') }}">Get started with smart contracts</a></li>
+                    <li><a href="{{ pathto('smart-contracts/guides/setup-tools') }}">Install the necessary tools</a></li>
+                    <li><a href="{{ pathto('smart-contracts/tutorials/piggy-bank/index') }}">Tutorial: Learn with the piggy bank  <br>  smart contract</a></li>
+                </ul>
             </div>
         </div>
         <div class="feature">
@@ -122,6 +128,7 @@
             display: flex;
             flex-direction: column;
             font-family: RobotoSlab;
+            overflow: visible;
         }   
 
         .info-container {
@@ -209,6 +216,10 @@
             text-align:center;
             position:relative;
             font-family: Lato;
+        }
+
+        .list-container ul {
+            padding-bottom: 50px;
         }
 
         .list-container ul li {

--- a/source/mainnet/_templates/index.html
+++ b/source/mainnet/_templates/index.html
@@ -20,12 +20,14 @@
         </a>
     </div>
 
-    < !╌ <div class="info-container">
+<!-- This can used to add a notification at the top of the landing page --
+     <div class="info-container">
         <div class="info-text">
             <h4>Please note</h4>
             <p>The Concordium native currency has been renamed from GTU to CCD, and the documentation and software is being updated to reflect this change. Because of this, you might encounter both terms and their respective symbols (Ǥ/Ͼ) in the documentation and software until the update is complete.</p>
         </div>
-    </div> -->
+    </div>
+--> 
 
     <div class="features-container">
         <div class="feature">

--- a/source/mainnet/_templates/index.html
+++ b/source/mainnet/_templates/index.html
@@ -20,12 +20,12 @@
         </a>
     </div>
 
-    <div class="info-container">
+    < !╌ <div class="info-container">
         <div class="info-text">
             <h4>Please note</h4>
             <p>The Concordium native currency has been renamed from GTU to CCD, and the documentation and software is being updated to reflect this change. Because of this, you might encounter both terms and their respective symbols (Ǥ/Ͼ) in the documentation and software until the update is complete.</p>
         </div>
-    </div>
+    </div> -->
 
     <div class="features-container">
         <div class="feature">

--- a/source/shared/net/concepts/id-accounts.rst
+++ b/source/shared/net/concepts/id-accounts.rst
@@ -10,7 +10,7 @@ Identities and accounts
 
 
 In order to be an active participant on the Concordium blockchain (e.g., hold,
-send, receive :ref:`glossary-CCD`) a user must create an *account*.
+send, receive :ref:'glossary-ccd') a user must create an *account*.
 
 The user will get an :ref:`glossary-initial-account` at the same time as an *identity* has been issued
 by an identity provider. As the initial account is submitted to the chain by the

--- a/source/shared/net/concepts/id-accounts.rst
+++ b/source/shared/net/concepts/id-accounts.rst
@@ -10,7 +10,7 @@ Identities and accounts
 
 
 In order to be an active participant on the Concordium blockchain (e.g., hold,
-send, receive :ref:'glossary-ccd') a user must create an *account*.
+send, receive :ref:`CCD<glossary-ccd>`) a user must create an *account*.
 
 The user will get an :ref:`glossary-initial-account` at the same time as an *identity* has been issued
 by an identity provider. As the initial account is submitted to the chain by the

--- a/source/shared/net/resources/glossary.rst
+++ b/source/shared/net/resources/glossary.rst
@@ -103,6 +103,24 @@ Consensus
 The process by which nodes agree which :ref:`transaction<glossary-transaction>` have occurred and in what
 order. This consists of :ref:`baking<glossary-baker>` and :ref:`finalization<glossary-finalization>`.
 
+.. _glossary-CCD
+
+CCD
+===
+
+CCD is the currency of the Concordium blockchain. CCD can be used for multiple
+purposes:
+
+-  as a form of payment between users via transactions,
+-  as a payment for executing smart contracts,
+-  as a store of value,
+-  as a reward for honest behaviour (e.g. :ref:`baking<glossary-baker>` or :ref:`finalizing<glossary-finalization>`
+   blocks on top of the longest chain), to incentivize blockchain users.
+
+The smallest subdivision of CCD is the µCCD (micro CCD), with 1 CCD = 1,000,000
+µCCD. This means that CCD amounts are given with up to six decimal places of
+precision.
+
 .. _glossary-credential:
 
 Credential
@@ -170,24 +188,6 @@ Genesis Block
 =============
 
 The first :ref:`block<glossary-block>` in a :ref:`chain<glossary-chain>`. The genesis block establishes the starting state of the chain, before any transactions have occurred.
-
-.. _glossary-CCD:
-
-Global Transaction Unit (CCD)
-=============================
-
-The currency of the Concordium blockchain. CCD can be used for multiple
-purposes:
-
--  as a form of payment between users via transactions,
--  as a payment for executing smart contracts,
--  as a store of value,
--  as a reward for honest behaviour (e.g. :ref:`baking<glossary-baker>` or :ref:`finalizing<glossary-finalization>`
-   blocks on top of the longest chain), to incentivize blockchain users.
-
-The smallest subdivision of CCD is the µCCD (micro CCD), with 1 CCD = 1,000,000
-µCCD. This means that CCD amounts are given with up to six decimal places of
-precision.
 
 .. _glossary-identity:
 

--- a/source/shared/net/resources/glossary.rst
+++ b/source/shared/net/resources/glossary.rst
@@ -86,24 +86,7 @@ Catch-up
 The mechanism by which a node receive messages that may have been missed, for
 instance because the node was offline when it was sent.
 
-.. _glossary-chain:
-
-Chain
-=====
-
-A sequence of :ref:`blocks<glossary-block>`, starting from the :ref:`genesis block<glossary-genesis-block>`, in which each
-successive block points to the predecessor. There may be multiple valid chains,
-and the :ref:`consensus<glossary-consensus>` protocol establishes which chain is authoritative.
-
-.. _glossary-consensus:
-
-Consensus
-=========
-
-The process by which nodes agree which :ref:`transaction<glossary-transaction>` have occurred and in what
-order. This consists of :ref:`baking<glossary-baker>` and :ref:`finalization<glossary-finalization>`.
-
-.. _glossary-CCD
+.. _glossary-ccd:
 
 CCD
 ===
@@ -120,6 +103,23 @@ purposes:
 The smallest subdivision of CCD is the µCCD (micro CCD), with 1 CCD = 1,000,000
 µCCD. This means that CCD amounts are given with up to six decimal places of
 precision.
+
+.. _glossary-chain:
+
+Chain
+=====
+
+A sequence of :ref:`blocks<glossary-block>`, starting from the :ref:`genesis block<glossary-genesis-block>`, in which each
+successive block points to the predecessor. There may be multiple valid chains,
+and the :ref:`consensus<glossary-consensus>` protocol establishes which chain is authoritative.
+
+.. _glossary-consensus:
+
+Consensus
+=========
+
+The process by which nodes agree which :ref:`transaction<glossary-transaction>` have occurred and in what
+order. This consists of :ref:`baking<glossary-baker>` and :ref:`finalization<glossary-finalization>`.
 
 .. _glossary-credential:
 


### PR DESCRIPTION
## Purpose

Remove all traces of GTU from documentation text.

## Changes

Updated Glossary file as this was the last remaining instance of GTU. Added CCD.
