### PR TITLE
Added missing space for note

### DIFF
--- a/source/shared/smart-contracts/general/contract-module.rst
+++ b/source/shared/smart-contracts/general/contract-module.rst
@@ -121,7 +121,7 @@ contracts, we associate the functions using a naming scheme:
   name for the function. Same as for the init function, the contract name is not allowed
   to contain the ``.`` symbol.
 
-..note::
+.. note::
 
    The function name is limited to 100 bytes. The whole function name must be ASCII alphanumeric and punctuation, not just the contract name.
 


### PR DESCRIPTION
## Purpose

To fix a typo that made a note appear incorrectly.

## Changes

Added a missing space between .. and note::

## Checklist

- [ X] My code follows the style of this project.
- [ X] The code compiles without warnings.
- [ X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X ] I accept the above linked CLA.
