### PR TITLE
Clarify configure baker docs

### DIFF
--- a/source/shared/net/guides/run-node-macos.rst
+++ b/source/shared/net/guides/run-node-macos.rst
@@ -219,7 +219,7 @@ On mainnet
 #. Edit the service file as an administrator. The service file is found here: ``/Library/Concordium
    Node/LaunchDaemons/software.concordium.mainnet.node.plist``
 
-#. Underneath the `<dict>` tag in the *EnviromentVariables* section of the file add the following::
+#. Underneath the ``<dict>`` tag in the *EnviromentVariables* section of the file add the following::
 
     <!-- Path to the baker credentials file. -->
     <key>CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE</key>

--- a/source/shared/net/guides/run-node-macos.rst
+++ b/source/shared/net/guides/run-node-macos.rst
@@ -219,7 +219,7 @@ On mainnet
 #. Edit the service file as an administrator. The service file is found here: ``/Library/Concordium
    Node/LaunchDaemons/software.concordium.mainnet.node.plist``
 
-#. In the *EnviromentVariables* section of the file add the following::
+#. Underneath the `<dict>` tag in the *EnviromentVariables* section of the file add the following::
 
     <!-- Path to the baker credentials file. -->
     <key>CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE</key>


### PR DESCRIPTION
## Purpose

Make it clear that you must insert the baker credential key-pair *underneath* the `<dict>` tag. 
This caused an issue for at least a single user, who contacted our support.

Here is a snippet of the service file to clarify the intent of this PR.
```
    ...
    <key>EnvironmentVariables</key>

     <!-- The baker credential location SHOULD NOT be inserted here -->

    <dict>

       <!-- The baker credential location SHOULD be inserted here.-->

        <!-- Port on which the node will listen for incoming connections. -->
        <key>CONCORDIUM_NODE_LISTEN_PORT</key>
        <string>8888</string>
        ...
```

We could also consider having the baker credentials key-pair already present in the service file but commented out.
Then we would need to explain to the users that they should remove the comment markers (`<!--`  and `-->`) when they want to become bakers. But I fear that this might cause even more trouble for the users.

## Changes

Explain that it should be inserted underneath the dict tag.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.