### PR TITLE
Added note about default path in run-node-ubuntu

### DIFF
--- a/source/mainnet/net/guides/run-node-ubuntu.rst
+++ b/source/mainnet/net/guides/run-node-ubuntu.rst
@@ -120,7 +120,7 @@ Configure the node with baker keys
       BindReadOnlyPaths=/home/user/concordium/baker-credentials.json:%S/concordium-9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478/baker-credentials.json
 
    Where you replace the path `/home/user/concordium/baker-credentials.json` with the actual location of the file.
-   
+
 .. Note::
    The path `%S/concordium-9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478/` is the default path to the baker's state directory, where `9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478` is the genesis hash.
 

--- a/source/mainnet/net/guides/run-node-ubuntu.rst
+++ b/source/mainnet/net/guides/run-node-ubuntu.rst
@@ -120,6 +120,9 @@ Configure the node with baker keys
       BindReadOnlyPaths=/home/user/concordium/baker-credentials.json:%S/concordium-9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478/baker-credentials.json
 
    Where you replace the path `/home/user/concordium/baker-credentials.json` with the actual location of the file.
+   
+.. Note::
+   The path `%S/concordium-9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478/` is the default path to the baker's state directory, where `9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478` is the genesis hash.
 
 #. Save the edited file.
 

--- a/source/testnet/net/guides/run-node-ubuntu.rst
+++ b/source/testnet/net/guides/run-node-ubuntu.rst
@@ -113,10 +113,13 @@ Configure the node with baker keys
 
       [Service]
 
-      Environment=CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE=%S/concordium-9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478/baker-credentials.json
-      BindReadOnlyPaths=/home/user/concordium/baker-credentials.json:%S/concordium-9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478/baker-credentials.json
+      Environment=CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE=%S/concordium-b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d/baker-credentials.json
+      BindReadOnlyPaths=/home/user/concordium/baker-credentials.json:%S/concordium-b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d/baker-credentials.json
 
    Where you replace the path `/home/user/concordium/baker-credentials.json` with the actual location of the file.
+
+.. Note::
+   The path `%S/concordium-b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d/` is the default path to the baker's state directory, where `b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d` is the testnet genesis hash.
 
 #. Save the edited file.
 


### PR DESCRIPTION
People may wonder whether they need to adjust the given path to something related to their setup. This is not the case. This update clarifies that the string is the genesis hash.

Furthermore, the testnet documentation used the same hash as the mainnet documentation. This was a mistake since testnet has a different genesis hash.

## Purpose

This pull request clarifies the documentation and fixes a bug in the testnet documentation.

## Changes

Added a note explaining the meaning of the provided path and fixed hash in testnet documentation.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

