### PR TITLE
Fix one reference to gtu in Smart Contract code example

### DIFF
--- a/source/shared/smart-contracts/tutorials/piggy-bank/testing.rst
+++ b/source/shared/smart-contracts/tutorials/piggy-bank/testing.rst
@@ -238,7 +238,7 @@ of our smart contract instance:
 .. code-block:: rust
 
    let ctx = ReceiveContextTest::empty();
-   let amount = Amount::from_micro_gtu(100);
+   let amount = Amount::from_micro_ccd(100);
    let mut state = PiggyBankState::Intact;
 
 When calling ``piggy_insert`` we get back a result with actions, instead of an


### PR DESCRIPTION
## Purpose

There was a reference in code that was not caught when references to GTU were replaced with CCD.

## Changes

Updated the code to reference CCD.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.

Closes #401 
