### PR TITLE
Add `$` to command examples where they were missing.

### DIFF
--- a/source/mainnet/net/guides/run-node-ubuntu.rst
+++ b/source/mainnet/net/guides/run-node-ubuntu.rst
@@ -39,7 +39,7 @@ The services are also enabled to start automatically on system start.
 
    .. code-block:: console
 
-    sudo apt install /path-to-downloaded-package
+    $sudo apt install /path-to-downloaded-package
 
   Where ``path-to-downloaded-package`` is the location of the downloaded ``.deb`` file.
 
@@ -87,7 +87,7 @@ To upgrade to a newer version of the `concordium-mainnet-node` package you need 
 
    .. code-block:: console
 
-    apt install ./concordium-mainnet-node_(version)_amd64.deb
+    $apt install ./concordium-mainnet-node_(version)_amd64.deb
 
   This step performs automatic database migration, so that the new node doesn't have to catch up from scratch. After installation is completed, the node and
   the collector are started as before.
@@ -109,7 +109,7 @@ Configure the node with baker keys
 
    .. code-block:: console
 
-      sudo systemctl edit concordium-mainnet-node.service
+      $sudo systemctl edit concordium-mainnet-node.service
 
 #. Add the following snippet to the opened file (the file is empty the first time you open it):
 
@@ -131,13 +131,13 @@ Configure the node with baker keys
 
    .. code-block:: console
 
-      sudo systemctl restart concordium-mainnet-node.service
+      $sudo systemctl restart concordium-mainnet-node.service
 
 #. To verify the node is running, enter:
 
    .. code-block:: console
 
-      sudo systemctl status concordium-mainnet-node.service
+      $sudo systemctl status concordium-mainnet-node.service
 
 Verify that a node is a baker node.
 -----------------------------------

--- a/source/shared/net/desktop-wallet/install-ledger-app.rst
+++ b/source/shared/net/desktop-wallet/install-ledger-app.rst
@@ -84,19 +84,19 @@ Restart your computer, and then confirm that Python and Pip were installed.
 
    .. code-block:: console
 
-      Python3 --version
+      $Python3 --version
 
 #. To confirm that the package manager named pip is installed, enter
 
    .. code-block:: console
 
-      pip --version
+      $pip --version
 
 #. To install Python tools for the Ledger Nano S, enter
 
    .. code-block:: console
 
-      pip install ledgerblue
+      $pip install ledgerblue
 
 Install the custom certificate on Windows
 -----------------------------------------
@@ -170,13 +170,13 @@ Install Homebrew, Python3, and pip
 
    .. code-block:: console
 
-      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      $/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 #. To install Python3, Pip3, `libusb <https://libusb.info/>`_, and `libjpeg <http://libjpeg.sourceforge.net/>`_, copy the following into the Terminal and press Enter:
 
    .. code-block:: console
 
-      brew install python@3.9 libusb libjpeg
+      $brew install python@3.9 libusb libjpeg
 
    You can use `pyenv<https://github.com/pyenv/pyenv>` if you need multiple python versions. Installing libjpeg is only necessary if you have a Mac with an M1 or similar Apple Silicon CPU.
 
@@ -184,7 +184,7 @@ Install Homebrew, Python3, and pip
 
    .. code-block:: console
 
-      pip3 install ledgerblue
+      $pip3 install ledgerblue
 
 Install the custom certificate using macOS
 ------------------------------------------
@@ -211,7 +211,7 @@ You now have to install a custom certificate to ensure that the Ledger trusts ap
 
    .. code-block:: console
 
-      ./loadcertificate.sh
+      $./loadcertificate.sh
 
 #. The Ledger says **Deny unsafe manager**. Press the right button to navigate through the public key until the Ledger says **Allow unsafe manager**. Press both buttons. You can safely ignore the message in the command-line window saying **Broken certificate chain - loading from user key**. This is expected behavior.
 
@@ -232,7 +232,7 @@ Install the Concordium Ledger app on MacOS
 
    .. code-block:: console
 
-      ./install.sh
+      $./install.sh
 
 #. The Ledger says **Deny unsafe manager**. Press the right button to navigate through the public key until the Ledger says **Allow unsafe manager**. Press both buttons. The Ledger says **Loading, please wait** while it installs the app.
 
@@ -281,32 +281,32 @@ Install Python3 and pip on Ubuntu
 
    .. code-block:: console
 
-      wget -q -O - https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | sudo bash
+      $wget -q -O - https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | sudo bash
 
 
 2. Install python3:
 
    .. code-block:: console
 
-      sudo apt-get install python3
+      $sudo apt-get install python3
 
 3. Install pip:
 
    .. code-block:: console
 
-      sudo apt-get install python3-pip
+      $sudo apt-get install python3-pip
 
 4. Install
 
    .. code-block:: console
 
-      sudo apt-get install libudev-dev libusb-1.0-0-dev python-dev
+      $sudo apt-get install libudev-dev libusb-1.0-0-dev python-dev
 
 5. Install ledgerblue:
 
    .. code-block:: console
 
-      sudo pip3 install ledgerblue
+      $sudo pip3 install ledgerblue
 
 Install the custom certificate on Ubuntu
 ----------------------------------------
@@ -329,7 +329,7 @@ You now have to install a custom certificate to ensure that the Ledger trusts ap
 
    .. code-block:: console
 
-      ./loadcertificate.sh
+      $./loadcertificate.sh
 
 #. The Ledger says **Deny unsafe manager**. Press the right button to navigate through the public key until the Ledger says **Allow unsafe manager**. Press both buttons. You can safely ignore the message in the command-line window saying **Broken certificate chain - loading from user key**. This is expected behavior.
 
@@ -344,7 +344,7 @@ Install the Concordium Ledger app on Ubuntu
 
    .. code-block:: console
 
-      ./install.sh
+      $./install.sh
 
 2. The Ledger says **Deny unsafe manager**. Press the right button to navigate through the public key until the Ledger says **Allow unsafe manager**. Press both buttons. The Ledger says **Loading, please wait** while it installs the app.
 

--- a/source/shared/net/guides/baker-windows.rst
+++ b/source/shared/net/guides/baker-windows.rst
@@ -27,13 +27,13 @@ Configure a baker node on Windows
 
    .. code-block:: console
 
-     concordium-client baker generate-keys <keys-file>.json
+     $concordium-client baker generate-keys <keys-file>.json
 
    and
 
    .. code-block:: console
 
-     concordium-client baker add <keys-file>.json --sender bakerAccount --stake <amount-to-stake> --out <concordium-data-dir>/baker-credentials.json
+     $concordium-client baker add <keys-file>.json --sender bakerAccount --stake <amount-to-stake> --out <concordium-data-dir>/baker-credentials.json
 
    In the following, the baker keys are referred to as baker-credentials.json.
 

--- a/source/shared/net/nodes/troubleshoot-macos.rst
+++ b/source/shared/net/nodes/troubleshoot-macos.rst
@@ -46,7 +46,7 @@ To see if this is your problem, try to load the service manually:
 
 .. code-block:: console
 
-   $ sudo launchctl load /Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist
+   $sudo launchctl load /Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist
 
 If your file ownership has changed, you will see the following:
 
@@ -59,4 +59,4 @@ To resolve the issue, change the file ownership back to root.
 
 .. code-block:: console
 
-   sudo chown root /Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist
+   $sudo chown root /Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist

--- a/source/shared/net/references/concordium-client.rst
+++ b/source/shared/net/references/concordium-client.rst
@@ -296,7 +296,7 @@ Show account aliases
 
 .. code-block:: console
 
-   $ concordium-client account show-alias 3ofwYFAkgV59BsHqzmiWyRmmKRB5ZzrPfbmx5nup24cE53jNX5 --alias 17
+   $concordium-client account show-alias 3ofwYFAkgV59BsHqzmiWyRmmKRB5ZzrPfbmx5nup24cE53jNX5 --alias 17
 
 This generates the output:
 

--- a/source/shared/net/references/transactions.rst
+++ b/source/shared/net/references/transactions.rst
@@ -157,7 +157,7 @@ To show aliases, enter:
 
 .. code-block:: console
 
-   $ concordium-client account show-alias 3ofwYFAkgV59BsHqzmiWyRmmKRB5ZzrPfbmx5nup24cE53jNX5 --alias 17
+   $concordium-client account show-alias 3ofwYFAkgV59BsHqzmiWyRmmKRB5ZzrPfbmx5nup24cE53jNX5 --alias 17
 
 This generates the output:
 

--- a/source/testnet/net/guides/run-node-ubuntu.rst
+++ b/source/testnet/net/guides/run-node-ubuntu.rst
@@ -39,7 +39,7 @@ The services are also enabled to start automatically on system start.
 
    .. code-block:: console
 
-    sudo apt install /path-to-downloaded-package
+    $sudo apt install /path-to-downloaded-package
 
   Where ``path-to-downloaded-package`` is the location of the downloaded ``.deb`` file.
 
@@ -86,7 +86,7 @@ To upgrade to a newer version of the `concordium-testnet-node` package you need 
 
    .. code-block:: console
 
-    apt install ./concordium-testnet-node_(version)_amd64.deb
+    $apt install ./concordium-testnet-node_(version)_amd64.deb
 
   This step performs automatic database migration, so that the new node doesn't have to catch up from scratch. After installation is completed, the node and the collector are started as before.
 
@@ -107,7 +107,7 @@ Configure the node with baker keys
 
    .. code-block:: console
 
-      sudo systemctl edit concordium-testnet-node.service
+      $sudo systemctl edit concordium-testnet-node.service
 
 #. Add the following snippet to the opened file (the file is empty the first time you open it):
 
@@ -129,13 +129,13 @@ Configure the node with baker keys
 
    .. code-block:: console
 
-      sudo systemctl restart concordium-testnet-node.service
+      $sudo systemctl restart concordium-testnet-node.service
 
 #. To verify the node is running, enter:
 
    .. code-block:: console
 
-      sudo systemctl status concordium-testnet-node.service
+      $sudo systemctl status concordium-testnet-node.service
 
 Verify that a node is a baker node.
 -----------------------------------


### PR DESCRIPTION
## Purpose

In support of #417 

This will make the copy button behave correctly in all examples, including multi-line ones.