### PR TITLE
Fix commands in mac troubleshooting

### DIFF
--- a/source/shared/net/nodes/troubleshoot-macos.rst
+++ b/source/shared/net/nodes/troubleshoot-macos.rst
@@ -46,7 +46,7 @@ To see if this is your problem, try to load the service manually:
 
 .. code-block:: console
 
-   $sudo launchctl load /Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist
+   $sudo launchctl load "/Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist"
 
 If your file ownership has changed, you will see the following:
 
@@ -59,4 +59,4 @@ To resolve the issue, change the file ownership back to root.
 
 .. code-block:: console
 
-   $sudo chown root /Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist
+   $sudo chown root "/Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist"


### PR DESCRIPTION
## Purpose

The commands were broken due to the space in `Concordium Node`. The space should either be escaped with `\`, i.e. `...Concordium\ Node...`, or the whole argument should be quoted.

## Changes

Quoted the commands

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.