### PR TITLE
Fix development links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ To watch the doc files and automate the build run:
 ```
 make dev-mainnet
 ```
-and navigate to [localhost:8000/mainnet](http://localhost:8000/mainnet).
+and navigate to [localhost:8000/mainnet](http://localhost:8000/net).
 
 **Testnet**
 ```
 make dev-testnet
 ```
-and navigate to [localhost:8000/testnet](http://localhost:8000/testnet).
+and navigate to [localhost:8000/testnet](http://localhost:8000/net).
 
 
 Before committing, make sure to run the linter and fix all the errors reported:
@@ -124,13 +124,13 @@ make lint
 ```
 make.bat dev-mainnet
 ```
-and navigate to [localhost:8000/mainnet](http://localhost:8000/mainnet).
+and navigate to [localhost:8000/mainnet](http://localhost:8000/net).
 
 **Testnet**
 ```
 make.bat dev-testnet
 ```
-and navigate to [localhost:8000/testnet](http://localhost:8000/testnet).
+and navigate to [localhost:8000/testnet](http://localhost:8000/net).
 
 
 Before committing, make sure to try to build and fix any warnings that are reported.


### PR DESCRIPTION
## Purpose

Correct the links in the readme. It is http://127.0.0.1/net/ for both mainnet and testnet when developing.

## Changes

Update links in readme

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.