### PR TITLE
Removed references to two hour window to submit

### DIFF
--- a/source/shared/net/desktop-wallet/multisig-simple-transfer.rst
+++ b/source/shared/net/desktop-wallet/multisig-simple-transfer.rst
@@ -46,10 +46,7 @@ Make a transfer proposal
 
 #.  Select the relevant recipient from the list. If there are many recipients in the list, you can use search to find the right recipient. Select **Continue**.
 
-#. Set the **Transaction expiry** time and then select **Continue**.
-
-.. Note::
-   You must submit proposals to the chain within the last 2 hours up to the expiry date, so take this into consideration, when you set the expiry time. It's important that you leave enough time for the co-signers to return their signatures in time.
+#. Set the **Transaction expiry** time, leaving enough time for the co-signers to return their signatures in time, and then select **Continue**.
 
 Generate the transaction
 ========================

--- a/source/shared/net/desktop-wallet/proposed-transactions.rst
+++ b/source/shared/net/desktop-wallet/proposed-transactions.rst
@@ -33,6 +33,6 @@ Transactions can have the following status:
 
 - **Finalized**: The proposal has been signed by all co-signers, the signatures have been imported, and the transaction has been submitted to the chain and :ref:`finalized <glossary-finalization>` on the chain.
 
-- **Expired**: The transaction was not submitted to the chain before the expiry time. You must submit proposals to the chain within the last 2 hours up to the expiry date. Otherwise, the proposal will expire, and you'll have to create a new one.
+- **Expired**: The transaction was not submitted to the chain before the expiry time. You must submit proposals to the chain before the expiry date. Otherwise, the proposal will expire, and you'll have to create a new one.
 
 - **Cancelled**: The proposal has been cancelled. You can cancel proposals with the status unsubmitted. This includes proposals that have been generated but not signed, proposals that have been generated and are awaiting signatures, and signed proposals that have not been submitted to the blockchain. Once a proposal has been submitted to the chain, you can't cancel it.

--- a/source/shared/net/desktop-wallet/remove-baker.rst
+++ b/source/shared/net/desktop-wallet/remove-baker.rst
@@ -42,7 +42,7 @@ Remove a baker (Multi-signature account)
 
 #. Select the **Account** that you no longer want to be a baker account, and then select **Continue**.
 
-#. Set an expiry date and time for your proposal. You must submit the proposal to the chain within the last 2 hours up to the expiry date. Consider this when you set the expiry time so that the co-signers can return their signatures in time. Select **Continue**.
+#. Set an expiry date and time for your proposal. You must set the expiry time so that the co-signers can return their signatures in time. Select **Continue**.
 
 Generate the transaction
 ------------------------

--- a/source/shared/net/desktop-wallet/update-baker-keys.rst
+++ b/source/shared/net/desktop-wallet/update-baker-keys.rst
@@ -44,7 +44,7 @@ Select an account (Multi-signature account)
 
 #. Select the **Account** whose baker keys you want to update, and then select **Continue**. Only baker accounts are listed.
 
-#. Set an expiry date and time for your proposal. You must submit the proposal to the chain within the last 2 hours up to the expiry date. Consider this when you set the expiry time so that the co-signers can return their signatures in time. Select **Generate keys**.
+#. Set an expiry date and time for your proposal. You must set the expiry time so that the co-signers can return their signatures in time. Select **Generate keys**.
 
    The baker keys are generated and you can view the transaction details in the left pane. You can see the identity, the account, and the expiry time of the transaction. You can also see the public baker keys.
 

--- a/source/shared/net/guides/multi-credentials.rst
+++ b/source/shared/net/guides/multi-credentials.rst
@@ -36,7 +36,7 @@ Select an identity and an account
 
 #. Select **Add Credential to proposal**, and then select **Continue**.
 
-#. Set an **expiry date and time** for your proposal. You must submit proposals to the chain within the last 2 hours up to the expiry date. This means you must set the expiry time so that it’s possible for any co-signers to return their signatures in time.
+#. Set an **expiry date and time** for your proposal. You must set the expiry time so that it’s possible for any co-signers to return their signatures in time.
 
 .. _guide-change-signature:
 

--- a/source/shared/net/guides/multisig-transfer.rst
+++ b/source/shared/net/guides/multisig-transfer.rst
@@ -73,10 +73,7 @@ Make a transfer proposal
 
 #.  Select the relevant recipient from the list. If there are many recipients in the list, you can use search to find the right recipient. Select **Continue**. You can now set up a release schedule.
 
-#. Set the **Transaction expiry** time. Select **Continue**.
-
-.. Note::
-   You must submit proposals to the chain within the last 2 hours up to the expiry date, so take this into consideration, when you set the expiry time. It's important that you leave enough time for the co-signers to return their signatures in time.
+#. Set the **Transaction expiry** time, leaving enough time for the co-signers to return their signatures in time. Select **Continue**.
 
 Add a release schedule
 ======================
@@ -101,9 +98,7 @@ Option 1: Create a regular interval schedule
 
 #.  When the schedule is complete, select **Continue**.
 
-#. Set the **Transaction expiry time** and then select **Continue**. You can see the release schedule under **Transaction Details**, and you can :ref:`generate the transaction <multisig-schedule-generate>`.
-
-You must submit proposals to the chain within the last 2 hours up to the expiry date, so take this into consideration, when you set the expiry time. It’s important that you leave enough time for the co-signers to return their signatures in time.
+#. Set the **Transaction expiry time**, leaving enough time for the co-signers to return their signatures in time, and then select **Continue**. You can see the release schedule under **Transaction Details**, and you can :ref:`generate the transaction <multisig-schedule-generate>`.
 
 .. _multisig-schedule-explicit:
 
@@ -124,7 +119,7 @@ Option 2: Create an explicit schedule
 
 #. When the schedule is complete, select **Continue**.
 
-#. Set the **Transaction expiry time** and then select **Continue**. You can see the release schedule under **Transaction Details**, and you can :ref:`generate the transaction <multisig-schedule-generate>`.
+#. Set the **Transaction expiry time**, leaving enough time for the co-signers to return their signatures in time, and then select **Continue**. You can see the release schedule under **Transaction Details**, and you can :ref:`generate the transaction <multisig-schedule-generate>`.
 
 .. _multisig-schedule-generate:
 


### PR DESCRIPTION
## Purpose

With node 4.0 there is no longer a need to refer to a two hour window for transaction submission to nodes.

## Changes

Updated the handful of files that referenced this. Kept the information about expiry but reworded to remove two hour window reference.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.

Closes #441 