### PR TITLE
Add downloads page for testnet

### DIFF
--- a/source/mainnet/net/index.rst
+++ b/source/mainnet/net/index.rst
@@ -8,6 +8,7 @@
    :caption: Installation
 
    installation/downloads
+   installation/downloads-testnet
    installation/verification-instructions
 
 .. toctree::

--- a/source/mainnet/net/installation/downloads-testnet.rst
+++ b/source/mainnet/net/installation/downloads-testnet.rst
@@ -1,0 +1,157 @@
+
+.. include:: ../../variables.rst
+.. _downloads-testnet:
+
+===================
+Downloads - Testnet
+===================
+
+This topic contains information about where you can download the Concordium Wallets and tools for Testnet. You can also find out about the hardware requirements for running a node.
+
+Concordium Mobile Wallet
+========================
+
+The Concordium Mobile Wallet is available for iOS and Android™. The Mobile Wallet supports iOS 13 or later and Android 8 or later.
+
+.. Note::
+
+   The Concordium Mobile Wallet is not supported on tablet devices.
+
+iOS
+---
+
+#.  Install `TestFlight <https://apps.apple.com/us/app/testflight/id899247664>`_ on your iPhone to get the Concordium Mobile Wallet for Testnet on iOS.
+#.  Follow `this link <https://testflight.apple.com/join/HZRi1WDT>`_ on your iPhone to join our beta. You must have TestFlight installed.
+
+Android
+-------
+
+- `Download the Android version of Concordium Mobile Wallet for Testnet <https://distribution.testnet.concordium.com/tools/android/concordium-mobile-wallet_2.0.0(75).apk>`_
+
+.. _downloads-desktop-wallet-testnet:
+
+Concordium Desktop Wallet v1.3.1
+================================
+
+- `Download the Testnet version of Concordium Desktop Wallet for Windows <https://distribution.testnet.concordium.com/tools/windows/concordium-desktop-wallet-testnet-1.3.1.exe>`_
+
+- `Download the Testnet version of Concordium Desktop Wallet for MacOS <https://distribution.testnet.concordium.com/tools/macos/concordium-desktop-wallet-testnet-1.3.1.dmg>`_
+
+- Download the Testnet version of Concordium Desktop Wallet for Linux®:
+
+- `Testnet AppImage <https://distribution.testnet.concordium.com/tools/linux/concordium-desktop-wallet-testnet-1.3.1.AppImage>`_
+
+   - SHA256 checksum of the download: ``59dc17c2cf47dfff8c60c0c662b7145cd08a10fcb44d1fa367ff62afa57e35c4``
+
+- `Testnet Debian package <https://distribution.testnet.concordium.com/tools/linux/concordium-desktop-wallet-testnet-1.3.1.deb>`_
+
+   - SHA256 checksum of the download: ``2bcd2f29498d5de58c049525b44508b675b4ef9afebd0d01052c555e7ee09b30``
+
+- `Testnet RPM <https://distribution.testnet.concordium.com/tools/linux/concordium-desktop-wallet-testnet-1.3.1.rpm>`_
+
+   - SHA256 checksum of the download: ``152885940a03502d63e5a052805f5d1a2a3252e3df18a9f719641b8f7bc4b3ef``
+
+Concordium Ledger App - Alpha Centauri
+======================================
+
+The version of the Ledger App is the same for Mainnet and Testnet. So if you already have that installed for one or the other, you do not need to reinstall.
+
+- `Download the Concordium Ledger App 2.0.3 for Ledger firmware version 2.1.0 <https://distribution.mainnet.concordium.software/tools/concordium-ledger-app-2.0.3-target-2.1.0.zip>`_
+- `Download the Concordium Ledger App 2.0.1 for Ledger firmware version 2.0.0 <https://distribution.mainnet.concordium.software/tools/concordium-ledger-app-2.0.1-target-2.0.0.zip>`_
+
+.. _concordium-node-and-client-download-testnet:
+
+Concordium Client v4.0.3
+========================
+
+-  `Download the Testnet Concordium Client for Linux <https://distribution.concordium.software/tools/linux/concordium-client_4.0.3-0>`_
+
+   - SHA256 checksum of the download: ``6ea2674ebae5dafd9de3c730db536fc0675627b6b867f05a944a1a60dd5ceca8``
+
+-  `Download the Testnet Concordium Client for macOS <https://distribution.concordium.software/tools/macos/concordium-client_4.0.3-0>`_
+
+-  `Download the Testnet Concordium Client for Windows <https://distribution.concordium.software/tools/windows/concordium-client_4.0.3-0.exe>`_
+
+Cargo-concordium v2.0.1
+=======================
+
+Download cargo-concordium:
+
+   -  `Download Testnet cargo-concordium for Linux <https://distribution.concordium.software/tools/linux/cargo-concordium_2.0.1-0>`_
+
+   -  `Download Testnet cargo-concordium for MacOS <https://distribution.concordium.software/tools/macos/cargo-concordium_2.0.1-0>`_
+
+   -  `Download Testnet cargo-concordium for Windows <https://distribution.concordium.software/tools/windows/cargo-concordium_2.0.1-0.exe>`_
+
+For information about installing cargo-concordium, see :ref:`Install tools for development <setup-tools>`.
+
+Concordium node distributions v4.0.11
+=====================================
+
+For the system requirements to run a node, see :ref:`System requirements to run a node<node-requirements>`.
+
+Ubuntu
+------
+
+To run a node on a server with Ubuntu, you need a Debian package.
+
+   - `Download the Testnet Debian package <https://distribution.testnet.concordium.com/deb/concordium-testnet-node_4.0.11_amd64.deb>`_
+
+      - SHA256 checksum of the download: ``12cfdc47a5f791ccaaadf46b4493e4cb144442228915c40bc8ae7906f9cb25a9``
+
+   To learn how to run a node with Ubuntu, see :ref:`Run a node on a server with Ubuntu <run-node-ubuntu>`.
+
+Linux-Docker
+------------
+
+Download the full suite for running a node on Linux using Docker. The suite contains Concordium Node, Concordium Client and cargo-concordium.
+
+   - `Download the Testnet suite for Linux <https://distribution.testnet.concordium.com/tools/linux/concordium-software-linux-4.0.11-0-testnet.tar.gz>`_
+
+      - SHA256 checksum of the download: ``05b4922b201015043d8bda7a3dce151e04897a122d77f1e03d72c2dbdbe1a29d``
+
+To learn how to run a node with Docker, see :ref:`Run a node with Docker <run-a-node>`.
+
+Windows
+-------
+
+To run a node on Windows, you need a Windows Installer package. **Please be aware that you should backup your configuration, as the installer will overwrite the current configuration with a standard configuration.**
+
+   - `Download the Testnet Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-4.0.11-0.msi>`_
+
+To learn how to run a node on Windows, see :ref:`Run and manage a node on Windows <run-node-windows>`.
+
+Mac
+---
+
+To run a node on macOS, you need a macOS installer package.
+
+   - `Download the Testnet macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-4.0.11.pkg>`_
+
+To learn how to run a node on Mac, see :ref:`Run and manage a node on macOS  <run-node-macos>`.
+
+Genesis block
+=============
+
+The genesis block is included in node distributions.
+Download the block separately to inspect it or to run a node in a custom configuration.
+
+   - `Download the testnet genesis block <https://distribution.testnet.concordium.com/data/genesis.dat>`_
+
+      - SHA256 checksum of the download: ``592a921e8b43185f1726037bf7e23e78a2ea22ced82179a0840d42088e28f44a``
+
+Auxiliary tools
+===============
+
+Auxiliary tools are a collection of tools that can be used by developers to perform actions as needed.
+
+Encrypt/decrypt tool v1.0.0
+---------------------------
+
+- `Download the Encrypt/decrypt tool for Linux <https://distribution.concordium.software/tools/linux/utils-1.0.0>`_
+
+- `Download the Encrypt/decrypt tool for Windows <https://distribution.concordium.software/tools/windows/signed/utils-1.0.0.zip>`_
+
+- `Download the Encrypt/decrypt tool for MacOS <https://distribution.concordium.software/tools/macos/signed/utils-1.0.0.zip>`_
+
+For information about how to use the encrypt/decrypt tool, see :ref:`Auxiliary tools  <developer-tools>`.

--- a/source/mainnet/net/installation/downloads.rst
+++ b/source/mainnet/net/installation/downloads.rst
@@ -2,13 +2,11 @@
 .. include:: ../../variables.rst
 .. _downloads:
 
-=========
-Downloads
-=========
+===================
+Downloads - Mainnet
+===================
 
-This topics contains information about where you can download the Concordium Wallets and tools for Mainnet and Testnet. You can also find out about the hardware requirements for running a node.
-
-For those downloads where there are separate packages for Mainnet or Testnet, select the appropriate tab to see the available packages.
+This topic contains information about where you can download the Concordium Wallets and tools for Mainnet. You can also find out about the hardware requirements for running a node.
 
 Concordium Mobile Wallet
 ========================
@@ -19,246 +17,129 @@ The Concordium Mobile Wallet is available for iOS and Android™. The Mobile Wal
 
    The Concordium Mobile Wallet is not supported on tablet devices.
 
-.. tabs::
+You can find Concordium Mobile Wallet on App Store and on Google Play.
 
-   .. tab:: Mainnet
+   .. image:: ../images/mobile-wallet/app-store-badge.svg
+      :width: 23%
+      :target: https://apps.apple.com/us/app/concordium-mobile-wallet/id1566996491
+   .. image:: ../images/mobile-wallet/google-play-badge.png
+      :width: 29.5%
+      :target: https://play.google.com/store/apps/details?id=software.concordium.mobilewallet.mainnet
 
-      You can find Concordium Mobile Wallet on App Store and on Google Play.
+The Concordium Mobile Wallet has been verified by NowSecure.
 
-      .. image:: ../images/mobile-wallet/app-store-badge.svg
-         :width: 23%
-         :target: https://apps.apple.com/us/app/concordium-mobile-wallet/id1566996491
-      .. image:: ../images/mobile-wallet/google-play-badge.png
-         :width: 29.5%
-         :target: https://play.google.com/store/apps/details?id=software.concordium.mobilewallet.mainnet
-
-      The Concordium Mobile Wallet has been verified by NowSecure.
-
-         .. image:: ../images/mobile-wallet/nowsecure_certificate.png
-            :width: 32%
-            :target: https://www.nowsecure.com/certified-apps/concordium/
-
-   .. tab:: Testnet
-
-      **iOS**
-
-      #.  Install `TestFlight <https://apps.apple.com/us/app/testflight/id899247664>`_ on your iPhone to get the Concordium Mobile Wallet for Testnet on iOS.
-      #.  Follow `this link <https://testflight.apple.com/join/HZRi1WDT>`_ on your iPhone to join our beta. You must have TestFlight installed.
-
-      **Android**
-
-      - `Download the Android version of Concordium Mobile Wallet for Testnet <https://distribution.testnet.concordium.com/tools/android/concordium-mobile-wallet_2.0.0(75).apk>`_
+   .. image:: ../images/mobile-wallet/nowsecure_certificate.png
+      :width: 32%
+      :target: https://www.nowsecure.com/certified-apps/concordium/
 
 .. _downloads-desktop-wallet:
 
-Concordium Desktop Wallet
-=========================
+Concordium Desktop Wallet v.1.3.1
+=================================
 
-.. tabs::
+-  `Download the Desktop Wallet for Windows <https://distribution.mainnet.concordium.software/tools/windows/concordium-desktop-wallet-1.3.1.exe>`_
 
-   .. tab:: Mainnet v1.3.1
+-  `Download the Desktop Wallet for macOS <https://distribution.mainnet.concordium.software/tools/macos/concordium-desktop-wallet-1.3.1.dmg>`_
 
-      -  `Download the Desktop Wallet for Windows <https://distribution.mainnet.concordium.software/tools/windows/concordium-desktop-wallet-1.3.1.exe>`_
+-  Download the Desktop Wallet for Linux®:
 
-      -  `Download the Desktop Wallet for macOS <https://distribution.mainnet.concordium.software/tools/macos/concordium-desktop-wallet-1.3.1.dmg>`_
+   -  `Mainnet AppImage <https://distribution.mainnet.concordium.software/tools/linux/concordium-desktop-wallet-1.3.1.AppImage>`_
 
-      -  Download the Desktop Wallet for Linux®:
+      - SHA256 checksum of the download: :substitution-code:`|cdw-appimage-checksum|`
+      - :ref:`Verification instructions <verification-cdw-appimage>`
 
-         -  `Mainnet AppImage <https://distribution.mainnet.concordium.software/tools/linux/concordium-desktop-wallet-1.3.1.AppImage>`_
+   -  `Mainnet Debian package <https://distribution.mainnet.concordium.software/tools/linux/concordium-desktop-wallet-1.3.1.deb>`_
 
-            - SHA256 checksum of the download: :substitution-code:`|cdw-appimage-checksum|`
-            - :ref:`Verification instructions <verification-cdw-appimage>`
+      - SHA256 checksum of the download: :substitution-code:`|cdw-deb-checksum|`
+      - :ref:`Verification instructions <verification-cdw-deb>`
 
-         -  `Mainnet Debian package <https://distribution.mainnet.concordium.software/tools/linux/concordium-desktop-wallet-1.3.1.deb>`_
+   -  `Mainnet RPM <https://distribution.mainnet.concordium.software/tools/linux/concordium-desktop-wallet-1.3.1.rpm>`_
 
-            - SHA256 checksum of the download: :substitution-code:`|cdw-deb-checksum|`
-            - :ref:`Verification instructions <verification-cdw-deb>`
+      - SHA256 checksum of the download: :substitution-code:`|cdw-rpm-checksum|`
+      - :ref:`Verification instructions <verification-cdw-rpm>`
 
-         -  `Mainnet RPM <https://distribution.mainnet.concordium.software/tools/linux/concordium-desktop-wallet-1.3.1.rpm>`_
-
-            - SHA256 checksum of the download: :substitution-code:`|cdw-rpm-checksum|`
-            - :ref:`Verification instructions <verification-cdw-rpm>`
-
-   .. tab:: Testnet v1.3.1
-
-      - `Download the Testnet version of Concordium Desktop Wallet for Windows <https://distribution.testnet.concordium.com/tools/windows/concordium-desktop-wallet-testnet-1.3.1.exe>`_
-
-      - `Download the Testnet version of Concordium Desktop Wallet for MacOS <https://distribution.testnet.concordium.com/tools/macos/concordium-desktop-wallet-testnet-1.3.1.dmg>`_
-
-      - Download the Testnet version of Concordium Desktop Wallet for Linux®:
-
-         - `Testnet AppImage <https://distribution.testnet.concordium.com/tools/linux/concordium-desktop-wallet-testnet-1.3.1.AppImage>`_
-
-            - SHA256 checksum of the download: ``59dc17c2cf47dfff8c60c0c662b7145cd08a10fcb44d1fa367ff62afa57e35c4``
-
-         - `Testnet Debian package <https://distribution.testnet.concordium.com/tools/linux/concordium-desktop-wallet-testnet-1.3.1.deb>`_
-
-            - SHA256 checksum of the download: ``2bcd2f29498d5de58c049525b44508b675b4ef9afebd0d01052c555e7ee09b30``
-
-         - `Testnet RPM <https://distribution.testnet.concordium.com/tools/linux/concordium-desktop-wallet-testnet-1.3.1.rpm>`_
-
-            - SHA256 checksum of the download: ``152885940a03502d63e5a052805f5d1a2a3252e3df18a9f719641b8f7bc4b3ef``
-
-Concordium Ledger App
-=====================
+Concordium Ledger App - Alpha Centauri
+======================================
 
 The version of the Ledger App is the same for Mainnet and Testnet. So if you already have that installed for one or the other, you do not need to reinstall.
 
-.. tabs::
-   .. tab:: Mainnet - Alpha Centauri
-
-      - `Download the Concordium Ledger App 2.0.3 for Ledger firmware version 2.1.0 <https://distribution.mainnet.concordium.software/tools/concordium-ledger-app-2.0.3-target-2.1.0.zip>`_
-      - `Download the Concordium Ledger App 2.0.1 for Ledger firmware version 2.0.0 <https://distribution.mainnet.concordium.software/tools/concordium-ledger-app-2.0.1-target-2.0.0.zip>`_
-
-   .. tab:: Testnet - Alpha Centauri
-
-      - `Download the Concordium Ledger App 2.0.3 for Ledger firmware version 2.1.0 <https://distribution.mainnet.concordium.software/tools/concordium-ledger-app-2.0.3-target-2.1.0.zip>`_
-      - `Download the Concordium Ledger App 2.0.1 for Ledger firmware version 2.0.0 <https://distribution.mainnet.concordium.software/tools/concordium-ledger-app-2.0.1-target-2.0.0.zip>`_
+- `Download the Concordium Ledger App 2.0.3 for Ledger firmware version 2.1.0 <https://distribution.mainnet.concordium.software/tools/concordium-ledger-app-2.0.3-target-2.1.0.zip>`_
+- `Download the Concordium Ledger App 2.0.1 for Ledger firmware version 2.0.0 <https://distribution.mainnet.concordium.software/tools/concordium-ledger-app-2.0.1-target-2.0.0.zip>`_
 
 .. _concordium-node-and-client-download:
 
-Concordium Client
-=================
+Concordium Client v3.0.4
+========================
 
-.. tabs::
-   .. tab:: Mainnet v3.0.4
+-  `Download the Mainnet Concordium Client for Linux <https://distribution.concordium.software/tools/linux/concordium-client_3.0.4-0>`_
 
-      -  `Download the Mainnet Concordium Client for Linux <https://distribution.concordium.software/tools/linux/concordium-client_3.0.4-0>`_
+   - SHA256 checksum of the download: :substitution-code:`|client-linux-checksum|`
+   - :ref:`Verification instructions <verification-client-linux>`
 
-         - SHA256 checksum of the download: :substitution-code:`|client-linux-checksum|`
-         - :ref:`Verification instructions <verification-client-linux>`
+-  `Download the Mainnet Concordium Client for macOS <https://distribution.concordium.software/tools/macos/signed/concordium-client_3.0.4-0.zip>`_.
 
-      -  `Download the Mainnet Concordium Client for macOS <https://distribution.concordium.software/tools/macos/signed/concordium-client_3.0.4-0.zip>`_.
+-  `Download the Mainnet Concordium Client for Windows <https://distribution.concordium.software/tools/windows/signed/concordium-client_3.0.4-0.exe>`_
 
-      -  `Download the Mainnet Concordium Client for Windows <https://distribution.concordium.software/tools/windows/signed/concordium-client_3.0.4-0.exe>`_
+Cargo-concordium v1.0.0-2
+=========================
 
-   .. tab:: Testnet v4.0.3
+Download cargo-concordium:
 
-      -  `Download the Testnet Concordium Client for Linux <https://distribution.concordium.software/tools/linux/concordium-client_4.0.3-0>`_
+   -  `Download Mainnet cargo-concordium for Linux <https://distribution.concordium.software/tools/linux/cargo-concordium_1.0.0-2>`_
 
-         - SHA256 checksum of the download: ``6ea2674ebae5dafd9de3c730db536fc0675627b6b867f05a944a1a60dd5ceca8``
+   -  `Download Mainnet cargo-concordium for MacOS <https://distribution.concordium.software/tools/macos/cargo-concordium_1.0.0-2>`_
 
-      -  `Download the Testnet Concordium Client for macOS <https://distribution.concordium.software/tools/macos/concordium-client_4.0.3-0>`_
-
-      -  `Download the Testnet Concordium Client for Windows <https://distribution.concordium.software/tools/windows/concordium-client_4.0.3-0.exe>`_
-
-Cargo-concordium
-================
-
-.. tabs::
-   .. tab:: Mainnet v1.0.0-2
-
-      Download cargo-concordium:
-
-      -  `Download Mainnet cargo-concordium for Linux <https://distribution.concordium.software/tools/linux/cargo-concordium_1.0.0-2>`_
-
-      -  `Download Mainnet cargo-concordium for MacOS <https://distribution.concordium.software/tools/macos/cargo-concordium_1.0.0-2>`_
-
-      -  `Download Mainnet cargo-concordium for Windows <https://distribution.concordium.software/tools/windows/cargo-concordium_1.0.0-2.exe>`_
-
-   .. tab:: Testnet v2.0.1
-
-      Download cargo-concordium:
-
-      -  `Download Testnet cargo-concordium for Linux <https://distribution.concordium.software/tools/linux/cargo-concordium_2.0.1-0>`_
-
-      -  `Download Testnet cargo-concordium for MacOS <https://distribution.concordium.software/tools/macos/cargo-concordium_2.0.1-0>`_
-
-      -  `Download Testnet cargo-concordium for Windows <https://distribution.concordium.software/tools/windows/cargo-concordium_2.0.1-0.exe>`_
+   -  `Download Mainnet cargo-concordium for Windows <https://distribution.concordium.software/tools/windows/cargo-concordium_1.0.0-2.exe>`_
 
 For information about installing cargo-concordium, see :ref:`Install tools for development <setup-tools>`.
 
-Concordium node distributions
-=============================
+Concordium node distributions v3.0.2
+====================================
 
 For the system requirements to run a node, see :ref:`System requirements to run a node<node-requirements>`.
 
-.. tabs::
+Ubuntu
+------
 
-   .. tab:: Mainnet  v3.0.2
+To run a node on a server with Ubuntu, you need a Debian package.
 
-      .. tabs::
+   - `Download the Mainnet Debian package <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_3.0.2_amd64.deb>`_
 
-         .. tab:: Ubuntu
+      - SHA256 checksum of the download: :substitution-code:`|node-deb-package-checksum|`
+      - :ref:`Verification instructions <verification-node-debian-package>`
 
-            To run a node on a server with Ubuntu, you need a Debian package.
+To learn how to run a node with Ubuntu, see :ref:`Run a node on a server with Ubuntu <run-node-ubuntu>`.
 
-            - `Download the Mainnet Debian package <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_3.0.2_amd64.deb>`_
+Docker-Linux
+------------
 
-               - SHA256 checksum of the download: :substitution-code:`|node-deb-package-checksum|`
-               - :ref:`Verification instructions <verification-node-debian-package>`
+.. _concordium-docker-package-download:
 
-            To learn how to run a node with Ubuntu, see :ref:`Run a node on a server with Ubuntu <run-node-ubuntu>`.
+Download the full suite for running a node on Linux using Docker. The suite contains Concordium Node, Concordium Client and cargo-concordium.
 
-         .. tab:: Docker-Linux
+   - `Download the Mainnet suite for Linux <https://distribution.mainnet.concordium.software/tools/linux/concordium-software-linux-3.0.2-0-mainnet.tar.gz>`_
 
-            .. _concordium-docker-package-download:
+      - SHA256 checksum of the download: ``733600b800f7a184152453a5aa52f6d0d50101a698804a957eb82c47ff2396f8``
 
-            Download the full suite for running a node on Linux using Docker. The suite contains Concordium Node, Concordium Client and cargo-concordium.
+To learn how to run a node with Docker, see :ref:`Run a node with Docker <run-a-node>`.
 
-               - `Download the Mainnet suite for Linux <https://distribution.mainnet.concordium.software/tools/linux/concordium-software-linux-3.0.2-0-mainnet.tar.gz>`_
+Windows
+-------
 
-                  - SHA256 checksum of the download: ``733600b800f7a184152453a5aa52f6d0d50101a698804a957eb82c47ff2396f8``
+To run a node on Windows, you need a Windows Installer package.
 
-            To learn how to run a node with Docker, see :ref:`Run a node with Docker <run-a-node>`.
+   - `Download the Mainnet Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-3.0.2.msi>`_
 
+To learn how to run a node on Windows, see :ref:`Run and manage a node on Windows <run-node-windows>`
 
-         .. tab:: Windows
+Mac
+---
 
-            To run a node on Windows, you need a Windows Installer package.
+To run a node on macOS, you need a macOS installer package.
 
-               - `Download the Mainnet Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-3.0.2.msi>`_
+   - `Download the Mainnet macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-3.0.2.pkg>`_
 
-            To learn how to run a node on Windows, see :ref:`Run and manage a node on Windows <run-node-windows>`
-
-
-         .. tab:: Mac
-
-            To run a node on macOS, you need a macOS installer package.
-
-               - `Download the Mainnet macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-3.0.2.pkg>`_
-
-            To learn how to run a node on Mac, see :ref:`Run and manage a node on macOS  <run-node-macos>`.
-
-   .. tab:: Testnet  v4.0.11
-
-      .. tabs::
-
-         .. tab:: Ubuntu
-
-            To run a node on a server with Ubuntu, you need a Debian package.
-
-               - `Download the Testnet Debian package <https://distribution.testnet.concordium.com/deb/concordium-testnet-node_4.0.11_amd64.deb>`_
-
-                  - SHA256 checksum of the download: ``12cfdc47a5f791ccaaadf46b4493e4cb144442228915c40bc8ae7906f9cb25a9``
-
-            To learn how to run a node with Ubuntu, see :ref:`Run a node on a server with Ubuntu <run-node-ubuntu>`.
-
-         .. tab:: Linux-Docker
-
-            Download the full suite for running a node on Linux using Docker. The suite contains Concordium Node, Concordium Client and cargo-concordium.
-
-               - `Download the Testnet suite for Linux <https://distribution.testnet.concordium.com/tools/linux/concordium-software-linux-4.0.11-0-testnet.tar.gz>`_
-
-                  - SHA256 checksum of the download: ``05b4922b201015043d8bda7a3dce151e04897a122d77f1e03d72c2dbdbe1a29d``
-
-            To learn how to run a node with Docker, see :ref:`Run a node with Docker <run-a-node>`.
-
-         .. tab:: Windows
-
-            To run a node on Windows, you need a Windows Installer package. **Please be aware that you should backup your configuration, as the installer will overwrite the current configuration with a standard configuration.**
-
-            - `Download the Testnet Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-4.0.11-0.msi>`_
-
-            To learn how to run a node on Windows, see :ref:`Run and manage a node on Windows <run-node-windows>`.
-
-         .. tab:: Mac
-
-            To run a node on macOS, you need a macOS installer package.
-
-            - `Download the Testnet macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-4.0.11.pkg>`_
-
-            To learn how to run a node on Mac, see :ref:`Run and manage a node on macOS  <run-node-macos>`.
+To learn how to run a node on Mac, see :ref:`Run and manage a node on macOS  <run-node-macos>`.
 
 Genesis block
 =============
@@ -266,19 +147,11 @@ Genesis block
 The genesis block is included in node distributions.
 Download the block separately to inspect it or to run a node in a custom configuration.
 
-.. tabs::
-   .. tab:: Mainnet
+- `Download the mainnet genesis block <https://distribution.mainnet.concordium.software/data/genesis.dat>`_
 
-      - `Download the mainnet genesis block <https://distribution.mainnet.concordium.software/data/genesis.dat>`_
+   - SHA256 checksum of the download: :substitution-code:`|mainnet-genesis-block-checksum|`
+   - :ref:`Verification instructions <verification-mainnet-genesis-block>`
 
-         - SHA256 checksum of the download: :substitution-code:`|mainnet-genesis-block-checksum|`
-         - :ref:`Verification instructions <verification-mainnet-genesis-block>`
-
-   .. tab:: Testnet
-
-      - `Download the testnet genesis block <https://distribution.testnet.concordium.com/data/genesis.dat>`_
-
-         - SHA256 checksum of the download: ``592a921e8b43185f1726037bf7e23e78a2ea22ced82179a0840d42088e28f44a``
 
 Auxiliary tools
 ===============


### PR DESCRIPTION
## Purpose

Due to a problem with functionality of tabs, it wasn't possible to link directly to a tab with bookmarks/anchors/permalinks. This was problematic when notifying users about updated download files.

## Changes

Added downloads page for testnet and removed tabs on both downloads pages.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
