### PR TITLE
Fix broken links to docs.rs

### DIFF
--- a/source/shared/smart-contracts/general/develop-contracts.rst
+++ b/source/shared/smart-contracts/general/develop-contracts.rst
@@ -347,5 +347,5 @@ macro, e.g.: ``#[init(..., payable)]`` and ``#[receive(..., payable)]``.
 .. |StateMap| replace:: ``StateMap``
 .. _StateSet: https://docs.rs/concordium-std/latest/concordium_std/struct.StateSet.html
 .. |StateSet| replace:: ``StateSet``
-.. _payable: https://docs.rs/concordium-std-derive/latest/concordium_std_derive/attr.init.html#payable-make-function-accept-an-amount-of-ccd..
+.. _payable: https://docs.rs/concordium-std-derive/latest/concordium_std_derive/attr.init.html#payable-make-function-accept-an-amount-of-ccd
 .. |payable| replace:: ``payable``

--- a/source/shared/smart-contracts/tutorials/piggy-bank/testing.rst
+++ b/source/shared/smart-contracts/tutorials/piggy-bank/testing.rst
@@ -55,7 +55,7 @@
 .. |claim_eq| replace:: ``claim_eq!``
 .. _ensure: https://docs.rs/concordium-std/latest/concordium_std/macro.ensure.html
 .. |ensure| replace:: ``ensure!``
-.. _mutable: https://docs.rs/concordium-std-derive/latest/concordium_std_derive/attr.receive.html#mutable-function-can-mutate-state
+.. _mutable: https://docs.rs/concordium-std-derive/latest/concordium_std_derive/attr.receive.html#mutable-function-can-mutate-the-state
 .. |mutable| replace:: ``mutable``
 
 .. _piggy-bank-testing:

--- a/source/shared/smart-contracts/tutorials/piggy-bank/writing.rst
+++ b/source/shared/smart-contracts/tutorials/piggy-bank/writing.rst
@@ -18,7 +18,7 @@
 .. |self_balance| replace:: ``self_balance``
 .. _invoke_transfer: https://docs.rs/concordium-std/latest/concordium_std/trait.HasHost.html#tymethod.invoke_transfer
 .. |invoke_transfer| replace:: ``invoke_transfer``
-.. _mutable: https://docs.rs/concordium-std-derive/latest/concordium_std_derive/attr.receive.html#mutable-function-can-mutate-state
+.. _mutable: https://docs.rs/concordium-std-derive/latest/concordium_std_derive/attr.receive.html#mutable-function-can-mutate-the-state
 .. |mutable| replace:: ``mutable``
 
 .. _piggy-bank-writing:


### PR DESCRIPTION
## Purpose

Fix docs.rs links in the documentation found after running the link checker.

## Changes

- Fix the links

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.