### PR TITLE
Add section on how to reset desktop wallet data

### DIFF
--- a/source/mainnet/net/desktop-wallet/reset-data.rst
+++ b/source/mainnet/net/desktop-wallet/reset-data.rst
@@ -4,18 +4,18 @@
 Reset desktop wallet data
 ==============================
 
-All the local data of the desktop wallet is stored in a database in the applications user data folder.
+All the local data of the desktop wallet is stored in a database in the user's applications data folder.
 
-The desktop wallet does not remove your user data when it is uninstalled, to avoid users losing their data, and to simplify the update process of the application.
+The desktop wallet does not remove your user data when it is uninstalled; this avoids users losing their data, and simplifies the update process for the application.
 
-We will here describe the process of deleting this user data, because it might be necessary to do, but you should make sure that you have a :ref:`backup <export-import>` with your data, before doing so.
+Occasionally, it might be necessary to delete the user data. The following steps describe the process of deleting this user data. Make sure that you have a :ref:`backup <export-import>` with your data before starting this process.
 
 .. warning:: Deleting the user data without a :ref:`backup <export-import>` will mean you can only recover what is recoverable with :ref:`account recovery <export-import>` (under "Recover accounts without a backup file"), which does not include your identities, address book, names or notes.
 
-Deleting the user data
+Delete the user data
 =========================================================
 
-Delete the following folder, containing all the user data of the wallet:
+Delete the following folder containing all the user data of the wallet:
 
 .. tabs::
 
@@ -39,4 +39,4 @@ Delete the following folder, containing all the user data of the wallet:
 
 .. Note:: To quickly navigate to the roaming folder on Windows, enter :code:`%appdata%` in the file explorer's navigation bar.
 
-When you next open the wallet, it will behave as a fresh installation, and prompt you to accept the terms and conditions and choose a new password.
+When you open the wallet for the first time after resetting the user data, it will behave as a fresh installation, and prompt you to accept the terms and conditions and choose a new password.

--- a/source/mainnet/net/desktop-wallet/reset-data.rst
+++ b/source/mainnet/net/desktop-wallet/reset-data.rst
@@ -1,0 +1,42 @@
+.. _reset-data:
+
+==============================
+Reset desktop wallet data
+==============================
+
+All the local data of the desktop wallet is stored in a database in the applications user data folder.
+
+The desktop wallet does not remove your user data when it is uninstalled, to avoid users losing their data, and to simplify the update process of the application.
+
+We will here describe the process of deleting this user data, because it might be necessary to do, but you should make sure that you have a :ref:`backup <export-import>` with your data, before doing so.
+
+.. warning:: Deleting the user data without a :ref:`backup <export-import>` will mean you can only recover what is recoverable with :ref:`account recovery <export-import>` (under "Recover accounts without a backup file"), which does not include your identities, address book, names or notes.
+
+Deleting the user data
+=========================================================
+
+Delete the following folder, containing all the user data of the wallet:
+
+.. tabs::
+
+   .. tab:: Mainnet
+
+            - MacOS: Users/<user>/Library/Application Support/Concordium Wallet
+
+            - Linux: ~/.config/Concordium Wallet
+
+            - Windows: Users/<user>/AppData/Roaming/Concordium Wallet
+
+
+   .. tab:: Testnet
+
+            - MacOS: Users/<user>/Library/Application Support/Concordium Wallet testnet
+
+            - Linux: ~/.config/Concordium Wallet testnet
+
+            - Windows: Users/<user>/AppData/Roaming/Concordium Wallet testnet
+
+
+.. Note:: To quickly navigate to the roaming folder on Windows, enter :code:`%appdata%` in the file explorer's navigation bar.
+
+When you next open the wallet, it will behave as a fresh installation, and prompt you to accept the terms and conditions and choose a new password.

--- a/source/mainnet/net/index.rst
+++ b/source/mainnet/net/index.rst
@@ -39,6 +39,7 @@
    desktop-wallet/transaction-log-filter
    desktop-wallet/update-application
    guides/overview-shared-accounts
+   desktop-wallet/reset-data
 
 .. toctree::
    :includehidden:

--- a/source/mainnet/net/resources/sirius-testnet-reset-wallets.rst
+++ b/source/mainnet/net/resources/sirius-testnet-reset-wallets.rst
@@ -14,4 +14,4 @@ Go to :ref:`Mobile Wallet downloads<downloads-mobile-wallet-testnet>` to get the
 Desktop Wallet
 ==============
 
-To clear the data of the wallet, uninstall it and follow :ref:`the instructions for resetting the wallet's data` (Remember to remove the testnet and *not* the mainnet files). Then reinstall the correct version for your platform. Go to :ref:`Desktop Wallet downloads<downloads-desktop-wallet-testnet>` to get the file for your platform.
+To clear the data of the wallet follow :ref:`the instructions for resetting the wallet's data` (Remember to remove the testnet and *not* the mainnet files). Go to :ref:`Desktop Wallet downloads<downloads-desktop-wallet-testnet>` to get the newest version.

--- a/source/mainnet/net/resources/sirius-testnet-reset-wallets.rst
+++ b/source/mainnet/net/resources/sirius-testnet-reset-wallets.rst
@@ -14,4 +14,4 @@ Go to :ref:`Mobile Wallet downloads<downloads-mobile-wallet-testnet>` to get the
 Desktop Wallet
 ==============
 
-Need instructions for how to get rid of data after uninstall. Then reinstall the correct version for your platform. Go to :ref:`Desktop Wallet downloads<downloads-desktop-wallet-testnet>` to get the file for your platform.
+To clear the data of the wallet, uninstall it and follow :ref:`the instructions for resetting the wallet's data` (Remember to remove the testnet and *not* the mainnet files). Then reinstall the correct version for your platform. Go to :ref:`Desktop Wallet downloads<downloads-desktop-wallet-testnet>` to get the file for your platform.


### PR DESCRIPTION
## Changes

- Added a section on how to reset desktop wallet data.
- Linked to it from sirius testnet reset page.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
