### PR TITLE
Move delegation faq and make titles clearer

### DIFF
--- a/source/mainnet/net/concepts/concepts-delegation.rst
+++ b/source/mainnet/net/concepts/concepts-delegation.rst
@@ -55,4 +55,11 @@ Summary
 
 To earn rewards, a CCD holder can either delegate to passive delegation, to a baking pool, or start their own baker. Baking oneself is the most challenging, as it requires resources to take part in the protocol, but it also provides the most rewards. Delegating to passive delegation provides the least rewards and requires the least actions from the investor. Delegating to a baking pool is somewhere between the two, both in terms of rewards and work, as it is recommended for a delegator to regularly check the performance of their pool’s baker, and change pool if it underperforms.
 
+.. toctree::
+    :hidden:
+    :maxdepth: 2
+
+    ../snippets/delegation-faq
+    ../desktop-wallet/delegation-dw
+
 See the :ref:`Delegation FAQ<delegation-faq>` for answers to the most frequently asked questions.

--- a/source/mainnet/net/concepts/index.rst
+++ b/source/mainnet/net/concepts/index.rst
@@ -1,7 +1,7 @@
 .. _concepts-index:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    id-accounts
    ../references/manage-accounts

--- a/source/mainnet/net/desktop-wallet/add-delegation.rst
+++ b/source/mainnet/net/desktop-wallet/add-delegation.rst
@@ -1,8 +1,8 @@
 .. _add-delegation:
 
-========================
-Delegate to a baker pool
-========================
+==============================================
+Delegate to a baker pool or passive delegation
+==============================================
 
 .. Note::
 
@@ -21,8 +21,8 @@ When you delegate some stake to a baker pool, it can influence the chances of th
 .. Warning::
    Make sure you have enough funds in your disposable balance to cover transaction fees.
 
-Delegate to a baker pool (Single-signature account)
-===================================================
+Delegate stake (Single-signature account)
+=========================================
 
 #. Go to **Accounts** and select the account on which you want to delegate funds.
 
@@ -48,8 +48,8 @@ Delegate to a baker pool (Single-signature account)
 
 #. In the Desktop Wallet, you can see that the transaction has been submitted to the chain. Select **Finish**.
 
-Delegate to a baker pool (Multi-signature account)
-==================================================
+Delegate stake (Multi-signature account)
+========================================
 
 #. Go to **Multi Signature Transactions**, select **Make new proposal**, and then select **Delegate to a pool**.
 

--- a/source/mainnet/net/desktop-wallet/delegation-dw.rst
+++ b/source/mainnet/net/desktop-wallet/delegation-dw.rst
@@ -27,9 +27,6 @@ You can only have one delegation per account. If you wish to delegate stake to m
    add-delegation
    update-delegation
    remove-delegation
+   ../snippets/delegation-faq
 
-.. _delegation-faq:
-
-The Delegation FAQ answers many commonly asked questions.
-
-.. include:: ../snippets/delegation-faq.rst
+The :ref:`Delegation FAQ<delegation-faq>` answers many commonly asked questions.

--- a/source/mainnet/net/desktop-wallet/remove-delegation.rst
+++ b/source/mainnet/net/desktop-wallet/remove-delegation.rst
@@ -1,8 +1,8 @@
 .. _remove-delegation:
 
-=================================
-Remove delegation to a baker pool
-=================================
+=======================================================
+Remove delegation to a baker pool or passive delegation
+=======================================================
 
 .. Note::
 

--- a/source/mainnet/net/desktop-wallet/update-delegation.rst
+++ b/source/mainnet/net/desktop-wallet/update-delegation.rst
@@ -1,8 +1,8 @@
 .. _update-delegation:
 
-=================================
-Update delegation to a baker pool
-=================================
+=======================================================
+Update delegation to a baker pool or passive delegation
+=======================================================
 
 .. Note::
 

--- a/source/mainnet/net/snippets/delegation-faq.rst
+++ b/source/mainnet/net/snippets/delegation-faq.rst
@@ -1,3 +1,5 @@
+.. _delegation-faq:
+
 Delegation FAQ
 ==============
 


### PR DESCRIPTION
## Purpose

There was a request to move the Delegation FAQ so it was in the sidebar menu.

## Changes

Added the FAQ under Delegation in Desktop Wallet and under Delegation in Learn about Concordium. Also expanded titles for delegation topics in Desktop wallet to mention passive delegation.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
