### PR TITLE
Add basic reference to cryptographic primitives.

### DIFF
--- a/source/mainnet/smart-contracts/references/crypto-primitives.rst
+++ b/source/mainnet/smart-contracts/references/crypto-primitives.rst
@@ -6,10 +6,10 @@ Cryptographic primitives
 
 V1 smart contracts natively support a number of common cryptographic primitives.
 Compared to implementing the same functionality in the smart contract, using primitives is subtantially cheaper.
-At the same time, smart contract developers benefit from using a single high-quality implementation of the primitives provided by the chain.
+At the same time, smart contract developers benefit from using a single, high-quality implementation of the primitives provided by the chain.
 
-Since all contract inputs, as well as the contract state, on the concordium blockchain are public it only reasonable to have primitives that take public inputs.
-The currently supported primitives are
+Since all contract inputs, as well as the contract state, on the Concordium blockchain are public, it only reasonable to have primitives that take public inputs.
+The currently supported primitives are:
 
 - Signature verification for the ``ed25519`` signature scheme,  and ``ECDSA`` over the ``Secp256k1`` signature scheme (Bitcoin/Ethereum signatures).
 - SHA2, SHA3, and Keccak digests with 256 bits of output.

--- a/source/mainnet/smart-contracts/references/crypto-primitives.rst
+++ b/source/mainnet/smart-contracts/references/crypto-primitives.rst
@@ -1,0 +1,22 @@
+.. _crypto-primitives:
+
+========================
+Cryptographic primitives
+========================
+
+V1 smart contracts natively support a number of common cryptographic primitives.
+Compared to implementing the same functionality in the smart contract, using primitives is subtantially cheaper.
+At the same time, smart contract developers benefit from using a single high-quality implementation of the primitives provided by the chain.
+
+Since all contract inputs, as well as the contract state, on the concordium blockchain are public it only reasonable to have primitives that take public inputs.
+The currently supported primitives are
+
+- Signature verification for the ``ed25519`` signature scheme,  and ``ECDSA`` over the ``Secp256k1`` signature scheme (Bitcoin/Ethereum signatures).
+- SHA2, SHA3, and Keccak digests with 256 bits of output.
+
+References
+==========
+
+- `an example contract <https://github.com/Concordium/concordium-rust-smart-contracts/blob/main/examples/signature-verifier/src/lib.rs>`_
+- `concordium-std documentation <https://docs.rs/concordium-std/3.0.0/concordium_std/trait.HasCryptoPrimitives.html>`_
+- :ref:`host function reference <host_function_crypto_primitives>`

--- a/source/mainnet/smart-contracts/references/host-fns.rst
+++ b/source/mainnet/smart-contracts/references/host-fns.rst
@@ -240,6 +240,58 @@ Smart contract instance state
             successful, or ``2^32 - 1`` if the entry does not exist.
    :rtype: i32
 
+.. _host_function_crypto_primitives:
+
+Cryptographic primitives
+========================
+
+.. function:: verify_ed25519_signature(public_key, signature, message, message_len) -> i32
+
+   Verify an ed25519 signature.
+
+   :param i32 public_key: Pointer to a public key in linear memory. The ``public_key`` must point to a 32-byte array.
+   :param i32 signature: Pointer to the claimed signature. The ``signature`` must point to a 64-byte array.
+   :param i32 message: Pointer to the beginning of the message.
+   :param i32 message_len: Length of the message in bytes.
+
+   :return: ``1`` if the signature check is successful, ``0`` if not.
+   :rtype: i32
+
+.. function:: verify_ecdsa_secp256k1_signature(public_key, signature, message) -> i32
+
+   Verify an ecdsa over secp256k1 signature with the bitcoin-core implementation.
+
+   :param i32 public_key: Pointer to a public key in linear memory. The ``public_key`` must point to a 33-byte array.
+   :param i32 signature: Pointer to the claimed signature. The ``signature`` must point to a 64-byte array, serialized in compressed format.
+   :param i32 message: Pointer to the beginning of the message. The message must be exactly 32-bytes long.
+
+   :return: ``1`` if the signature check is successful, ``0`` if not.
+   :rtype: i32
+
+.. function:: hash_sha2_256(data, data_len, output)
+
+   Compute the SHA2-256 digest of the data.
+
+   :param i32 data: Pointer to the beginning of the data.
+   :param i32 data_len: Length of the data in bytes.
+   :param i32 output: Pointer to a memory location where the digest will be written.
+
+.. function:: hash_sha3_256(data, data_len, output)
+
+   Compute the SHA3-256 digest of the data.
+
+   :param i32 data: Pointer to the beginning of the data.
+   :param i32 data_len: Length of the data in bytes.
+   :param i32 output: Pointer to a memory location where the digest will be written.
+
+.. function:: hash_keccak_256(data, data_len, output)
+
+   Compute the Keccak-256 digest of the data.
+
+   :param i32 data: Pointer to the beginning of the data.
+   :param i32 data_len: Length of the data in bytes.
+   :param i32 output: Pointer to a memory location where the digest will be written.
+
 .. _host_function_chain_getters:
 
 Chain data

--- a/source/mainnet/smart-contracts/references/index.rst
+++ b/source/mainnet/smart-contracts/references/index.rst
@@ -10,10 +10,11 @@ A number of references exist to help you when creating and testing smart contrac
    :maxdepth: 1
    :caption: References
 
+   crypto-primitives
+   host-fns
+   local-settings
+   references-on-chain
    schema-json
    simulate-context
-   host-fns
-   references-on-chain
-   local-settings
    Rust contract examples (repo) <https://github.com/Concordium/concordium-rust-smart-contracts>
    concordium-std <https://docs.rs/concordium-std/3.0.0/concordium_std/>


### PR DESCRIPTION
## Purpose

Add reference for cryptographic primitives in V1 contracts.

Closes https://github.com/Concordium/concordium-rust-smart-contracts/issues/117

## Changes

- Add reference page to make it them discoverable.
- Add host functions reference.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.