### PR TITLE
Add commission rates for passive delegation to documentation

### DIFF
--- a/source/mainnet/net/concepts/concepts-delegation.rst
+++ b/source/mainnet/net/concepts/concepts-delegation.rst
@@ -35,6 +35,12 @@ Passive delegation
 
 For CCD holders who do not want to regularly check the performance of their pool, but just want a safe way of earning interest, :ref:`passive delegation<glossary-passive-delegation>` offers a low-risk low-reward alternative. Passive delegation is not associated with a specific baker; it can be thought of as distributing its capital to each pool in proportion to the pool's stake. It is not affected by the poor performance of a single baker. But the parameters are set in such a way that a party delegating to passive delegation earns less than by delegating to a reliable baker.
 
+The commission rates for passive delegation are:
+
+- Baking commission: 12.00%
+- Finalization commission: 100.00%
+- Transaction commission: 12.00%
+
 Time and cool-downs
 ===================
 

--- a/source/mainnet/net/snippets/delegation-faq.rst
+++ b/source/mainnet/net/snippets/delegation-faq.rst
@@ -53,6 +53,12 @@ It could be because the baker to whose pool you have delegated stake was not sel
 **What is “passive delegation”?**
 For CCD holders who do not want to regularly check the performance of a chosen pool but just want a stable way of earning rewards, passive delegation offers a low-risk, low-reward alternative. This staking strategy is not associated with a specific baker, so there is no risk of poor baker health. The trade off when choosing passive delegation is that the rewards will be less than what you may receive when delegating to a specific baker pool.
 
+The commission rates for passive delegation are:
+
+- Baking commission: 12.00%
+- Finalization commission: 100.00%
+- Transaction commission: 12.00%
+
 **My account is suddenly delegating to passive delegation. Why is that?**
 It is likely because the baker pool to which you were delegating has been closed. You can continue to delegate to passive delegation or select a new baker pool for your delegation.
 


### PR DESCRIPTION
## Purpose

Management wants the commission rates for passive delegation added to the documentation.

## Changes

Added the rates to the concept topic.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
