### PR TITLE
Add installation instructions for the mac client

### DIFF
--- a/source/mainnet/net/installation/downloads-testnet.rst
+++ b/source/mainnet/net/installation/downloads-testnet.rst
@@ -87,7 +87,7 @@ Concordium Client v4.0.3
 
 -  `Download the Testnet Concordium Client for macOS <https://distribution.concordium.software/tools/macos/signed/concordium-client_4.0.3-0.pkg>`_
 
-   - The macOS distribution is an installer, which places an alias to the binary
+   - The macOS distribution is an installer that places an alias to the binary
      into the folder ``/usr/local/bin``. So after installing, you should have
      ``concordium-client`` on your path.
 

--- a/source/mainnet/net/installation/downloads-testnet.rst
+++ b/source/mainnet/net/installation/downloads-testnet.rst
@@ -33,7 +33,7 @@ Android
 .. _downloads-desktop-wallet-testnet:
 
 Concordium Desktop Wallet
-================================
+=========================
 
 Windows v1.4.1
 --------------
@@ -83,7 +83,11 @@ Concordium Client v4.0.3
 
    - SHA256 checksum of the download: ``7d082dfc8dad0d5b9099a62e80728c0527fa5453fa686a7b24bc1b7b7527e1da``
 
--  `Download the Testnet Concordium Client for macOS <https://distribution.concordium.software/tools/macos/signed/concordium-client_4.0.3-0.zip>`_
+-  `Download the Testnet Concordium Client for macOS <https://distribution.concordium.software/tools/macos/signed/concordium-client_4.0.3-0.pkg>`_
+
+   - The macOS distribution is an installer, which places an alias to the binary
+     into the folder ``/usr/local/bin``. So after installing, you should have
+     ``concordium-client`` on your path.
 
 -  `Download the Testnet Concordium Client for Windows <https://distribution.concordium.software/tools/windows/signed/concordium-client_4.0.3-0.exe>`_
 


### PR DESCRIPTION
## Purpose

Add installation instructions for concordium client on mac now that it is a package instead of a zip.
I've only added it to testnet as I assume we will be releasing that first.

**Note that the download link must be updated before publishing.**

Closes https://github.com/Concordium/concordium-node/issues/404

## Changes

- Add install instructions to concordium client for mac on testnet

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.