### PR TITLE
Clarify the port mapping in the example configuration file.

### DIFF
--- a/source/mainnet/net/guides/run-node.rst
+++ b/source/mainnet/net/guides/run-node.rst
@@ -99,6 +99,12 @@ To run a node on testnet use the following configuration file and follow the ste
        # by `CONCORDIUM_NODE_LISTEN_PORT` and `CONCORDIUM_NODE_RPC_SERVER_PORT`)
        # should match what is defined here. When running multiple nodes the
        # external ports should be changed so as not to conflict.
+       # In the mapping below, the first port is the `host` port, and the second
+       # port is the `container` port. When the `container` port is changed the
+       # relevant environment variable listed above must be changed as well. For
+       # example, changing `10001:10001` to `10001:13000` would mean that
+       # `CONCORDIUM_NODE_RPC_SERVER_PORT` should be set to `13000`. Otherwise
+       # the node's gRPC interface will not be available from the host.
        ports:
        - "8889:8889"
        - "10001:10001"
@@ -281,6 +287,12 @@ Logs of the mainnet node can be retrieved by running:
        # by `CONCORDIUM_NODE_LISTEN_PORT` and `CONCORDIUM_NODE_RPC_SERVER_PORT`)
        # should match what is defined here. When running multiple nodes the
        # external ports should be changed so as not to conflict.
+       # In the mapping below, the first port is the `host` port, and the second
+       # port is the `container` port. When the `container` port is changed the
+       # relevant environment variable listed above must be changed as well. For
+       # example, changing `10000:10000` to `10000:13000` would mean that
+       # `CONCORDIUM_NODE_RPC_SERVER_PORT` should be set to `13000`. Otherwise
+       # the node's gRPC interface will not be available from the host.
        ports:
        - "8888:8888"
        - "10000:10000"


### PR DESCRIPTION
## Purpose

Make it easier to change ports in the docker configurations.