### PR TITLE
Update migration notes to include baker details

### DIFF
--- a/source/mainnet/net/guides/run-node.rst
+++ b/source/mainnet/net/guides/run-node.rst
@@ -348,7 +348,14 @@ image and running the node. To migrate from that setup:
    Or, alternatively, moving the contents of ``~/.local/share/concordium`` to,
    e.g., ``/var/lib/concordium-mainnet`` and keeping the configuration files as
    they are.
-3. Start the new node.
+3. If your node is a existing baker node, update the configuration file above to include
+
+   .. code-block:: yaml
+
+      - CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE=/mnt/data/baker-credentials.json
+
+   into the ``environment`` section of the ``node`` service section of the file.
+4. Start the new node.
 
 Troubleshooting
 ===============

--- a/source/mainnet/net/guides/run-node.rst
+++ b/source/mainnet/net/guides/run-node.rst
@@ -348,7 +348,7 @@ image and running the node. To migrate from that setup:
    Or, alternatively, moving the contents of ``~/.local/share/concordium`` to,
    e.g., ``/var/lib/concordium-mainnet`` and keeping the configuration files as
    they are.
-3. If your node is a existing baker node, update the configuration file above to include
+3. If your node is an existing baker node, update the configuration file above to include
 
    .. code-block:: yaml
 


### PR DESCRIPTION
The migration documentation is missing the migration steps for a existing baker node

## Purpose

Its not clear in the migration documentation how to continue to be a baker when you migrate your existing docker baker setup. If you dont double check, its very easy to miss that the new node isnt a baker.

## Changes

Information on how to include environment variable activating the baker credentials.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
