### PR TITLE
Change order of -f argument to start node

### DIFF
--- a/source/mainnet/net/guides/run-node.rst
+++ b/source/mainnet/net/guides/run-node.rst
@@ -157,7 +157,7 @@ To run a node on testnet use the following configuration file and follow the ste
 
    .. code-block:: console
 
-      $docker-compose up -f testnet-node.yaml
+      $docker-compose -f testnet-node.yaml up
 
 The configuration will start two containers, one running the node, and another
 running the node collector that reports the node state to the network dashboard.


### PR DESCRIPTION
This is the correct order of docker-compose -f argument, it has to go before "up" command
docker-compose [-f <arg>...] [options] [COMMAND] [ARGS...]

## Purpose

Documentation showing wrong order of arguments and the command will fail when trying to start the node.

## Changes

The argument -f testnet-node.yaml has to come before "up" command.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
