### PR TITLE
Small fixes to the wCCD documentation

### DIFF
--- a/source/mainnet/smart-contracts/guides/fallback-entrypoints.rst
+++ b/source/mainnet/smart-contracts/guides/fallback-entrypoints.rst
@@ -1,4 +1,4 @@
-.. fallback-entrypoints:
+.. _fallback-entrypoints:
 
 ====================
 Fallback entrypoints

--- a/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-interacting.rst
+++ b/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-interacting.rst
@@ -340,7 +340,7 @@ State-mutative functions
 
 The protocol has four state-mutative functions (``wrap``, ``unwrap``,
 ``transfer``, and ``updateOperator``) that you can invoke on the ``proxy`` contract.
-These invokes will be passed through the ``proxy`` to the ``implementation`` contract (via the `fallback entrypoint <https://github.com/Concordium/concordium-rust-smart-contracts/blob/main/examples/proxy/src/lib.rs#L48>`_).
+These invokes will be passed through the ``proxy`` to the ``implementation`` contract (via the :ref:`fallback entrypoint <fallback-entrypoints>`).
 They require a different schema and JSON file with your input parameters for every invoke.
 All schema files used in this tutorial can be `downloaded <https://github.com/Concordium/concordium.github.io/tree/main/source/mainnet/smart-contracts/tutorials/wCCD/schemas>`_
 or you can create them as described in the

--- a/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-introduction.rst
+++ b/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-introduction.rst
@@ -73,11 +73,11 @@ The canonical wCCD smart contract protocol following the ``CIS-2`` standard
 is deployed on ``testnet`` at the following addresses:
 
 +-----------------------------------------------------+-------------------------------------------------+
-| ``ProxyContractAddress (Testnet):``                 |  { index: 864, subindex: 0 }                    |
+| ``ProxyContractAddress (Testnet):``                 |  { index: 866, subindex: 0 }                    |
 +-----------------------------------------------------+-------------------------------------------------+
 | ``ImplementationContractAddress (Testnet):``        |  { index: 865, subindex: 0 }                    |
 +-----------------------------------------------------+-------------------------------------------------+
-| ``StateContractAddress (Testnet):``                 |  { index: 866, subindex: 0 }                    |
+| ``StateContractAddress (Testnet):``                 |  { index: 864, subindex: 0 }                    |
 +-----------------------------------------------------+-------------------------------------------------+
 |                                                     |                                                 |
 +-----------------------------------------------------+-------------------------------------------------+


### PR DESCRIPTION
## Fixes

- protocol addresses were swapped around
- fallback function explanation link goes to the documentation now and not to the code


- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
