### PR TITLE
Add information about error schemas

### DIFF
--- a/source/mainnet/smart-contracts/guides/build-schema.rst
+++ b/source/mainnet/smart-contracts/guides/build-schema.rst
@@ -51,20 +51,24 @@ how this type is represented as bytes and how to represent it.
 Including schemas for init
 --------------------------
 
-To generate and include the schema for parameters for init functions, set the optional ``parameter`` attribute for the
+To generate and include the schema for parameters or errors for init functions, set the
+optional ``parameter`` and ``error`` attributes for the
 ``#[init(..)]``-macro::
 
    #[derive(SchemaType)]
    enum InitParameter { ... }
 
-   #[init(contract = "my_contract", parameter = "InitParameter")]
-   fn contract_init<...> (...){ ... }
+   #[derive(Serial, Reject, SchemaType)]
+   enum InitError { ... }
+
+   #[init(contract = "my_contract", parameter = "InitParameter", error = "InitError")]
+   fn contract_init<...>(...) -> <..., InitError> { ... }
 
 Including schemas for receive
 -----------------------------
 
-To generate and include the schema for parameters or return values for receive
-functions, set the optional ``parameter`` or ``return_value`` attribute for the
+To generate and include the schema for parameters, return values, or errors for receive
+functions, set the optional ``parameter``, ``return_value``, or ``error`` attributes for the
 ``#[receive(..)]``-macro::
 
    #[derive(SchemaType)]
@@ -73,19 +77,26 @@ functions, set the optional ``parameter`` or ``return_value`` attribute for the
    #[derive(SchemaType)]
    enum ReceiveReturnValue { ... }
 
+   #[derive(Serial, Reject, SchemaType)]
+   enum ReceiveError { ... }
+
    #[receive(contract = "my_contract", name = "just_param", parameter = "String")]
    fn contract_receive_just_param<...> (...) -> ReceiveResult<String> { ... }
 
    #[receive(contract = "my_contract", name = "just_return", return_value = "Vec<u64>")]
    fn contract_receive_just_return<...> (...) -> ReceiveResult<Vec<u64>> { ... }
 
+   #[receive(contract = "my_contract", name = "just_return", error = "ReceiveError")]
+   fn contract_receive_just_erro<...> (...) -> Result<Vec<u64>, ReceiveError> { ... }
+
    #[receive(
        contract = "my_contract",
        name = "param_and_return",
        parameter = "ReceiveParameter",
-       return_value = "ReceiveReturnValue"
+       return_value = "ReceiveReturnValue",
+       error = "ReceiveError"
    )]
-   fn contract_receive_param_and_return<...> (...) -> ReceiveResult<ReceiveReturnValue> { ... }
+   fn contract_receive<...> (...) -> Result<ReceiveReturnValue, ReceiveError> { ... }
 
 Building the schema
 ===================

--- a/source/mainnet/smart-contracts/guides/custom-errors.rst
+++ b/source/mainnet/smart-contracts/guides/custom-errors.rst
@@ -13,13 +13,17 @@ Defining and deriving
 Custom error codes help communicate why a contract rejects and can be returned
 both during initialization and during updates.
 
-On-chain, smart contracts return a numeric error code when rejecting. This is
-also the case when using a custom error type. Therefore, a mapping from the
-custom error type to ``Reject``, in the form of an implementation of
-``From<MyError> for Reject``, is needed. We can also derive it
-automatically using ``#[derive(Reject)]``::
+On-chain, smart contracts return a numeric error code and an optional serialized
+return value when rejecting. This is also the case when using a custom error type.
+Therefore, a mapping from the custom error type to ``Reject``, in the
+form of an implementation of ``From<MyError> for Reject``, is needed.
+You can derive the implementation automatically with ``#[derive(Reject)]``, if
+the type also implements ``Serial`` (also derivable). The ``Serial`` instance is
+needed, because the whole data type is serialized and included as the optional
+return value.
+Here is a typical example::
 
-   #[derive(Reject)]
+   #[derive(Serial, Reject)]
    enum MyError {
        ErrOne,
        ErrTwo,
@@ -34,9 +38,7 @@ automatically using ``#[derive(Reject)]``::
 
 .. warning::
 
-   Deriving ``Reject`` is only possible for fieldless enums, i.e., enums where
-   the variants do not have associated data. Additionally, derivation for enums
-   with `custom discriminant values`_ is not supported either.
+   Deriving ``Reject`` for enums with `custom discriminant values`_ is not supported.
 
 Using custom errors
 ===================
@@ -56,3 +58,8 @@ Return custom errors, as you would with any other error type:
        _ctx: &impl HasReceiveContext,
        _host: &impl HasHost<State, StateApiType = S>
    ) -> Result<MyReturnValue, MyError> { Err(MyError::ErrTwo) }
+
+.. note::
+
+   Adding  :ref:`schemas<build-schema>` to your errors makes them more useful in
+   ``concordium-client`` and ``cargo-concordium``.

--- a/source/mainnet/smart-contracts/guides/custom-errors.rst
+++ b/source/mainnet/smart-contracts/guides/custom-errors.rst
@@ -17,9 +17,9 @@ On-chain, smart contracts return a numeric error code and an optional serialized
 return value when rejecting. This is also the case when using a custom error type.
 Therefore, a mapping from the custom error type to ``Reject``, in the
 form of an implementation of ``From<MyError> for Reject``, is needed.
-You can derive the implementation automatically with ``#[derive(Reject)]``, if
+You can derive the implementation automatically with ``#[derive(Reject)]`` if
 the type also implements ``Serial`` (also derivable). The ``Serial`` instance is
-needed, because the whole data type is serialized and included as the optional
+needed because the whole data type is serialized and included as the optional
 return value.
 Here is a typical example::
 

--- a/source/mainnet/smart-contracts/tutorials/piggy-bank/testing.rst
+++ b/source/mainnet/smart-contracts/tutorials/piggy-bank/testing.rst
@@ -454,7 +454,7 @@ reasons for rejection:
 
 .. code-block:: rust
 
-   #[derive(Debug, PartialEq, Eq, Reject)]
+   #[derive(Debug, PartialEq, Eq, Serial, Reject)]
    enum SmashError {
        NotOwner,
        AlreadySmashed,


### PR DESCRIPTION
## Purpose

Add information about error schemas and fix example code

## Changes

- Explain why deriving `Reject` now requires `Serial`
- Remove warning about deriving reject on enums with fields
- Fix examples

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
