### PR TITLE
Update downloads with command to run in Linux

### DIFF
--- a/source/mainnet/net/installation/downloads-testnet.rst
+++ b/source/mainnet/net/installation/downloads-testnet.rst
@@ -91,7 +91,9 @@ Concordium Client v4.1.0
 
       .. code-block:: console
 
-         chmod +x concordium-client
+         chmod +x concordium-client_*
+
+   where you replace `*` with |client-version|.
 
 -  `Download the Testnet Concordium Client for macOS <https://distribution.concordium.software/tools/macos/signed/concordium-client-4.1.0.pkg>`_
 

--- a/source/mainnet/net/installation/downloads-testnet.rst
+++ b/source/mainnet/net/installation/downloads-testnet.rst
@@ -86,7 +86,7 @@ Concordium Client v4.1.0
    - SHA256 checksum of the download: |client-linux-checksum|
 
    |
-   
+
    When you run Concordium Client on Linux, run the following command to make the file you download executable:
 
       .. code-block:: console

--- a/source/mainnet/net/installation/downloads-testnet.rst
+++ b/source/mainnet/net/installation/downloads-testnet.rst
@@ -87,7 +87,7 @@ Concordium Client v4.1.0
 
    |
 
-   When you run Concordium Client on Linux, run the following command to make the file you download executable:
+   Before you can use the downloaded Concordium Client on Linux you have to make the downloaded file executable. Run the following command to make the file you download executable:
 
       .. code-block:: console
 

--- a/source/mainnet/net/installation/downloads-testnet.rst
+++ b/source/mainnet/net/installation/downloads-testnet.rst
@@ -85,6 +85,14 @@ Concordium Client v4.1.0
 
    - SHA256 checksum of the download: |client-linux-checksum|
 
+   |
+   
+   When you run Concordium Client on Linux, run the following command to make the file you download executable:
+
+      .. code-block:: console
+
+         chmod +x concordium-client
+
 -  `Download the Testnet Concordium Client for macOS <https://distribution.concordium.software/tools/macos/signed/concordium-client-4.1.0.pkg>`_
 
    - The macOS distribution is an installer that places an alias to the binary

--- a/source/mainnet/net/installation/downloads.rst
+++ b/source/mainnet/net/installation/downloads.rst
@@ -84,11 +84,13 @@ Concordium Client v4.1.0
       - SHA256 checksum of the download: :substitution-code:`|client-linux-checksum|`
       - :ref:`Verification instructions <verification-client-linux>`
 
-   When you run Concordium Client on Linux, run the following command to make the file you download executable:
+   Before you can use the downloaded Concordium Client on Linux you have to make the downloaded file executable. Run the following command to make the file you download executable:
 
       .. code-block:: console
 
-         chmod +x concordium-client
+         chmod +x concordium-client_*
+
+   where you replace `*` with |client-version|.
 
 -  `Download the Mainnet Concordium Client for macOS <https://distribution.concordium.software/tools/macos/signed/concordium-client-4.1.0.pkg>`_
 

--- a/source/mainnet/net/installation/downloads.rst
+++ b/source/mainnet/net/installation/downloads.rst
@@ -84,6 +84,12 @@ Concordium Client v4.1.0
       - SHA256 checksum of the download: :substitution-code:`|client-linux-checksum|`
       - :ref:`Verification instructions <verification-client-linux>`
 
+   When you run Concordium Client on Linux, run the following command to make the file you download executable:
+
+      .. code-block:: console
+
+         chmod +x concordium-client
+
 -  `Download the Mainnet Concordium Client for macOS <https://distribution.concordium.software/tools/macos/signed/concordium-client-4.1.0.pkg>`_
 
    - The macOS distribution is an installer that places an alias to the binary

--- a/source/mainnet/net/references/concordium-client.rst
+++ b/source/mainnet/net/references/concordium-client.rst
@@ -38,9 +38,9 @@ flags are supported by all ``concordium-client`` commands.
 Run Concordium Client
 =====================
 
-Run Concordium Client from the command line. On MacOS or Linux, access the command line with the Terminal application. On Windows, use the Power Shell or Command Prompt application. If you run it outside of the command line (e.g., by double clicking in Windows Explorer), then the concordium client will exit immediately without doing anything useful.
+Run Concordium Client from the command line. On MacOS or Linux, access the command line with the Terminal application. On Windows, use the Power Shell or Command Prompt application. If you run it outside of the command line (e.g., by double clicking in Windows Explorer), then the Concordium Client will exit immediately without doing anything useful.
 
-To run the Concordium Client, you have to specify its full path unless you are in the same directory. If using MacOS the installation puts it in $PATH so that you can  type concordium-client from anywhere. You must specify the file name, including the version number. For example, assuming that you saved the ``concordium-client_4.0.4-0.exe`` in the Downloads folder of a user called User, then the full path is probably ``C:\Users\User\Downloads\concordium-client_4.0.4-0.exe``. So you enter the full path at the prompt in the terminal.
+To run the Concordium Client, you have to specify its full path unless you are in the same directory. If using MacOS the installation puts it in $PATH so that you can type ``concordium-client`` from anywhere. You must specify the file name, including the version number. For example, assuming that you saved the ``concordium-client_4.0.4-0.exe`` in the Downloads folder of a user called User, then the full path is probably ``C:\Users\User\Downloads\concordium-client_4.0.4-0.exe``. So you enter the full path at the prompt in the terminal.
 
 When running commands for the Concordium Client in the terminal, replace concordium-client with ``C:\Users\User\Downloads\concordium-client_<version>.exe`` as in the following example:
 

--- a/source/mainnet/variables.rst
+++ b/source/mainnet/variables.rst
@@ -15,6 +15,7 @@
 
 .. Client verification variables
 .. |client-linux| replace:: concordium-client_4.1.0
+.. |client-version| replace:: 4.1.0
 .. |client-linux-checksum| replace:: 3f5e32835ec029e0eb6298aee7eca1b2b13e457575f756568a4d2f06788840b9
 
 .. Node debian package verification variables


### PR DESCRIPTION
## Purpose

Inform users they need to run a command when they have downloaded the Linux version of Concordium Client to make the file executable.

## Changes

Added to downloads pages. On the testnet page I cannot remove the extra line space because Sphinx does not like it if there is not a blank line after the bullet. And because it is variable text and not regular text I have to put in a pipe to force space. Otherwise the text for the addition is jammed up against the checksum.

Also minor corrections to concordium client topic.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
