### PR TITLE
Add cargo concordium init documentation

### DIFF
--- a/source/mainnet/net/installation/downloads-testnet.rst
+++ b/source/mainnet/net/installation/downloads-testnet.rst
@@ -118,16 +118,16 @@ Concordium Client v4.1.0
 
 -  `Download the Testnet Concordium Client for Windows <https://distribution.concordium.software/tools/windows/signed/concordium-client_4.1.0.exe>`_
 
-Cargo-concordium v2.1.0
+Cargo-concordium v2.2.0
 =======================
 
 Download cargo-concordium:
 
-   -  `Download Testnet cargo-concordium for Linux <https://distribution.concordium.software/tools/linux/cargo-concordium_2.1.0>`_
+   -  `Download Testnet cargo-concordium for Linux <https://distribution.concordium.software/tools/linux/cargo-concordium_2.2.0>`_
 
-   -  `Download Testnet cargo-concordium for MacOS <https://distribution.concordium.software/tools/macos/cargo-concordium_2.1.0>`_
+   -  `Download Testnet cargo-concordium for MacOS <https://distribution.concordium.software/tools/macos/cargo-concordium_2.2.0>`_
 
-   -  `Download Testnet cargo-concordium for Windows <https://distribution.concordium.software/tools/windows/cargo-concordium_2.1.0.exe>`_
+   -  `Download Testnet cargo-concordium for Windows <https://distribution.concordium.software/tools/windows/cargo-concordium_2.2.0.exe>`_
 
 For information about installing `cargo-concordium`, see :ref:`Install tools for development <setup-tools>`.
 

--- a/source/mainnet/net/installation/downloads.rst
+++ b/source/mainnet/net/installation/downloads.rst
@@ -115,16 +115,16 @@ Concordium Client v4.1.0
 
 -  `Download the Mainnet Concordium Client for Windows <https://distribution.concordium.software/tools/windows/signed/concordium-client_4.1.0.exe>`_
 
-Cargo-concordium v2.1.0
+Cargo-concordium v2.2.0
 =======================
 
 Download cargo-concordium:
 
-   -  `Download Mainnet cargo-concordium for Linux <https://distribution.concordium.software/tools/linux/cargo-concordium_2.1.0>`_
+   -  `Download Mainnet cargo-concordium for Linux <https://distribution.concordium.software/tools/linux/cargo-concordium_2.2.0>`_
 
-   -  `Download Mainnet cargo-concordium for MacOS <https://distribution.concordium.software/tools/macos/cargo-concordium_2.1.0>`_
+   -  `Download Mainnet cargo-concordium for MacOS <https://distribution.concordium.software/tools/macos/cargo-concordium_2.2.0>`_
 
-   -  `Download Mainnet cargo-concordium for Windows <https://distribution.concordium.software/tools/windows/cargo-concordium_2.1.0.exe>`_
+   -  `Download Mainnet cargo-concordium for Windows <https://distribution.concordium.software/tools/windows/cargo-concordium_2.2.0.exe>`_
 
 For information about installing `cargo-concordium`, see :ref:`Install tools for development <setup-tools>`.
 

--- a/source/mainnet/net/resources/release-notes-mainnet.rst
+++ b/source/mainnet/net/resources/release-notes-mainnet.rst
@@ -12,6 +12,13 @@ Mainnet 4: Sirius
 
    Prior to Sirius, the nodes enforced that a transaction could not be deployed until 2 hours before its expiry date. With Sirius, node validation of transactions has been improved and the 2 hour window has been removed.
 
+October 12, 2022
+
+Cargo concordium 2.2.0
+----------------------
+
+Cargo concordium 2.2.0 introduces the ``init`` subcommand that can initialize a new project and use contract templates to set up an initial project.
+
 September 26, 2022
 
 |mw-gen2|

--- a/source/mainnet/net/resources/release-notes-mainnet.rst
+++ b/source/mainnet/net/resources/release-notes-mainnet.rst
@@ -12,7 +12,7 @@ Mainnet 4: Sirius
 
    Prior to Sirius, the nodes enforced that a transaction could not be deployed until 2 hours before its expiry date. With Sirius, node validation of transactions has been improved and the 2 hour window has been removed.
 
-October 12, 2022
+October 10, 2022
 
 Cargo concordium 2.2.0
 ----------------------

--- a/source/mainnet/net/resources/release-notes.rst
+++ b/source/mainnet/net/resources/release-notes.rst
@@ -12,7 +12,7 @@ Sirius Testnet
 
    Prior to Sirius, the nodes enforced that a transaction could not be deployed until 2 hours before its expiry date. With Sirius, node validation of transactions has been improved and the 2 hour window has been removed.
 
-October 12, 2022
+October 10, 2022
 
 Cargo concordium 2.2.0
 ----------------------

--- a/source/mainnet/net/resources/release-notes.rst
+++ b/source/mainnet/net/resources/release-notes.rst
@@ -12,6 +12,12 @@ Sirius Testnet
 
    Prior to Sirius, the nodes enforced that a transaction could not be deployed until 2 hours before its expiry date. With Sirius, node validation of transactions has been improved and the 2 hour window has been removed.
 
+October 12, 2022
+
+Cargo concordium 2.2.0
+----------------------
+
+Cargo concordium 2.2.0 introduces the ``init`` subcommand that can initialize a new project and use contract templates to set up an initial project.
 
 September 29, 2022
 

--- a/source/mainnet/smart-contracts/guides/setup-contract.rst
+++ b/source/mainnet/smart-contracts/guides/setup-contract.rst
@@ -7,7 +7,7 @@ Setting up a smart contract project
 ===================================
 
 This guide documents two different options (`from a template` or `from scratch`) to create a new Concordium smart contract project.
-The `from a template` option provides you with some
+The `from a template` option is available for ``cargo-concordium`` version 2.2.0 or greater. It provides you with some
 smart contract templates. Choose the template that best fits your project scope.
 The `from scratch` option guides you through the process when you want to start a new project without any boilerplate code.
 
@@ -17,23 +17,22 @@ The `from scratch` option guides you through the process when you want to start 
 From a template:
 ================
 
-Concordium maintains several smart contract templates (currently a ``default`` template and a ``cis2-nft`` template).
+Concordium maintains several smart contract
+`templates <https://github.com/Concordium/concordium-rust-smart-contracts/tree/main/templates>`_ (currently a ``default`` template and a ``cis2-nft`` template).
+For generating the smart contracts from the above templates, the ``cargo-generate`` crate is required.
+``cargo-generate`` can be installed by running the following command:
+
+.. code-block:: console
+
+   $cargo install --locked cargo-generate
+
 To start a new Concordium smart contract project from a template, run the command:
 
 .. code-block:: console
 
    $cargo concordium init
 
-This command generates a new project from the templates in the
-`template folder <https://github.com/Concordium/concordium-rust-smart-contracts>`_.
 The path where the project should be created can be provided with the ``--path`` option.
-The ``cargo-generate`` crate is required for running the above command. ``cargo-generate`` can
-be installed by running the following command:
-
-.. code-block:: console
-
-   $cargo install --locked cargo-generate
-
 
 From scratch:
 =============

--- a/source/mainnet/smart-contracts/guides/setup-contract.rst
+++ b/source/mainnet/smart-contracts/guides/setup-contract.rst
@@ -6,6 +6,38 @@
 Setting up a smart contract project
 ===================================
 
+This guide documents two different options (`from a template` or `from scratch`) to create a new Concordium smart contract project.
+The `from a template` option provides you with some
+smart contract templates. Choose the template that best fits your project scope.
+The `from scratch` option guides you through the process when you want to start a new project without any boilerplate code.
+
+.. note::
+   We recommend that newcomers choose the `from a template` option and select the ``default`` template to start with.
+
+From a template:
+================
+
+Concordium maintains several smart contract templates (currently a ``default`` template and a ``cis2-nft`` template).
+To start a new Concordium smart contract project from a template, run the command:
+
+.. code-block:: console
+
+   $cargo concordium init
+
+This command generates a new project from the templates in the
+`template folder <https://github.com/Concordium/concordium-rust-smart-contracts>`_.
+The path where the project should be created can be provided with the ``--path`` option.
+The ``cargo-generate`` crate is required for running the above command. ``cargo-generate`` can
+be installed by running the following command:
+
+.. code-block:: console
+
+   $cargo install --locked cargo-generate
+
+
+From scratch:
+=============
+
 A smart contract in Rust is written as an ordinary Rust library crate.
 The library is then compiled to Wasm using the Rust target
 ``wasm32-unknown-unknown`` and, since it is just a Rust library, we can use
@@ -29,29 +61,7 @@ This is done by adding the following in the ``Cargo.toml`` file ::
    [lib]
    crate-type = ["cdylib", "rlib"]
 
-
-Starting a smart contract project from a template
-=================================================
-
-Concordium maintains several smart contract templates (currently a ``default`` template and a ``cis2-nft`` template).
-To start a new Concordium smart contract project from a template, run the command:
-
-.. code-block:: console
-
-   $cargo concordium init
-
-This command generates a new project from the templates in the
-`template folder <https://github.com/Concordium/concordium-rust-smart-contracts>`_.
-The path where the project should be created can be provided with the ``--path`` option.
-The ``cargo-generate`` crate is required for running the above command. ``cargo-generate`` can
-be installed by running the following command:
-
-.. code-block:: console
-
-   $cargo install --locked cargo-generate
-
-Adding the smart contract standard library
-==========================================
+**Adding the smart contract standard library**
 
 The next step is to add ``concordium-std`` as a dependency.
 It is a library for Rust containing procedural macros and functions for

--- a/source/mainnet/smart-contracts/guides/setup-contract.rst
+++ b/source/mainnet/smart-contracts/guides/setup-contract.rst
@@ -6,16 +6,16 @@
 Setting up a smart contract project
 ===================================
 
-This guide documents two different options (`from a template` or `from scratch`) to create a new Concordium smart contract project.
-The `from a template` option is available for ``cargo-concordium`` version 2.2.0 or greater. It provides you with some
+This guide documents two different options (*from a template* or *from scratch*) to create a new Concordium smart contract project.
+The *from a template* option is available for ``cargo-concordium`` version 2.2.0 or greater. It provides you with some
 smart contract templates. Choose the template that best fits your project scope.
-The `from scratch` option guides you through the process when you want to start a new project without any boilerplate code.
+The *from scratch* option guides you through the process when you want to start a new project without any boilerplate code.
 
 .. note::
-   We recommend that newcomers choose the `from a template` option and select the ``default`` template to start with.
+   We recommend that newcomers choose the *from a template* option.
 
-From a template:
-================
+From a template
+===============
 
 Concordium maintains several smart contract
 `templates <https://github.com/Concordium/concordium-rust-smart-contracts/tree/main/templates>`_ (currently a ``default`` template and a ``cis2-nft`` template).
@@ -34,8 +34,8 @@ To start a new Concordium smart contract project from a template, run the comman
 
 The path where the project should be created can be provided with the ``--path`` option.
 
-From scratch:
-=============
+From scratch
+============
 
 A smart contract in Rust is written as an ordinary Rust library crate.
 The library is then compiled to Wasm using the Rust target

--- a/source/mainnet/smart-contracts/guides/setup-contract.rst
+++ b/source/mainnet/smart-contracts/guides/setup-contract.rst
@@ -29,6 +29,27 @@ This is done by adding the following in the ``Cargo.toml`` file ::
    [lib]
    crate-type = ["cdylib", "rlib"]
 
+
+Starting a smart contract project from a template
+=================================================
+
+Concordium maintains several smart contract templates (currently a ``default`` template and a ``cis2-nft`` template).
+To start a new Concordium smart contract project from a template, run the command:
+
+.. code-block:: console
+
+   $cargo concordium init
+
+This command generates a new project from the templates in the
+`template folder <https://github.com/Concordium/concordium-rust-smart-contracts>`_.
+The path where the project should be created can be provided with the ``--path`` option.
+The ``cargo-generate`` crate is required for running the above command. ``cargo-generate`` can
+be installed by running the following command:
+
+.. code-block:: console
+
+   $cargo install --locked cargo-generate
+
 Adding the smart contract standard library
 ==========================================
 


### PR DESCRIPTION
## Purpose
closes #610 

document `cargo concordium init` command

**Note:** This documentation should be published after https://github.com/Concordium/concordium-smart-contract-tools/pull/7 is merged and a new cargo-concordium version 2.2.0 is released.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.