### PR TITLE
Add template improvements

### DIFF
--- a/source/mainnet/smart-contracts/guides/compile-module.rst
+++ b/source/mainnet/smart-contracts/guides/compile-module.rst
@@ -53,3 +53,19 @@ This uses Cargo_ for building, but runs further optimizations on the result.
 
    Note that even with ``--release`` set, the produced Wasm module includes
    debug information.
+
+Running the ``cargo concordium build`` command will produce a smart contract module which can be found
+relative to your project root folder in ``./target/concordium/wasm32-unknown-unknown/release/my_module.wasm.v1``.
+Alternatively, you can run the following command to output your smart contract module into the root folder of your project:
+
+.. code-block:: console
+
+   $cargo concordium build --out ./my_module.wasm.v1
+
+.. note::
+
+   ``cargo-concordium`` produces several smart contract modules with different suffixes. The suffix corresponds
+   to the smart contract version, i.e. ``my_module.wasm/my_module.wasm.v0`` for V0 contracts and ``my_module.wasm.v1``
+   for V1 contracts. We recommend using the wasm module with the ``.v1`` extension
+   (the most-up-to date smart contract version).
+   The file ``my_module.wasm.v1`` will be used when :ref:`deploying <deploy-module>` a smart contract on-chain.

--- a/source/mainnet/smart-contracts/guides/compile-module.rst
+++ b/source/mainnet/smart-contracts/guides/compile-module.rst
@@ -56,7 +56,9 @@ This uses Cargo_ for building, but runs further optimizations on the result.
 
 Running the ``cargo concordium build`` command will produce a smart contract module which can be found
 relative to your project root folder in ``./target/concordium/wasm32-unknown-unknown/release/my_module.wasm.v1``.
-Alternatively, you can run the following command to output your smart contract module into the root folder of your project:
+Alternatively, you can supply the location where to store the smart contract module using
+the ``--out`` option. For example running the following command will output your smart contract module
+into the root folder of your project in a file name ``my_module.wasm.v1``.
 
 .. code-block:: console
 

--- a/source/mainnet/smart-contracts/guides/local-simulate.rst
+++ b/source/mainnet/smart-contracts/guides/local-simulate.rst
@@ -25,6 +25,8 @@ You will also need a smart contract module in Wasm to simulate.
 
    Write the rest, when the schema stuff is in place.
 
+.. _simulating-instantiation:
+
 Simulating instantiation
 ========================
 
@@ -76,7 +78,7 @@ An example of a fully specified init context could be:
 Simulating updates
 ==================
 
-To simulate an update to a contract smart contract instance using
+To simulate an update to a smart contract instance using
 ``cargo-concordium``, run:
 
 .. code-block:: console
@@ -93,6 +95,12 @@ To simulate an update to a contract smart contract instance using
 
    If using :ref:`contract schemas<build-schema>`, it is possible to pass
    the parameter as JSON instead of binary by using the ``--parameter-json`` flag.
+
+.. note::
+
+   The simulation of the ``init`` function in the :ref:`previous
+   paragraph<simulating-instantiation>` produced an output ``state.bin`` file.
+   This ``state.bin`` file can be used as the input ``state-in.bin`` file in this paragraph.
 
 ``receive-context.json`` (used with the ``--context`` parameter) is a file that
 contains context information such as the current state of the chain, the

--- a/source/mainnet/smart-contracts/guides/setup-contract.rst
+++ b/source/mainnet/smart-contracts/guides/setup-contract.rst
@@ -35,6 +35,9 @@ To start a new Concordium smart contract project from a template, run the comman
 
 The path where the project should be created can be provided with the ``--path`` option.
 
+You can find additional information on the available templates in the
+`README file <https://github.com/Concordium/concordium-rust-smart-contracts/tree/main/templates/README.md>`_.
+
 From scratch
 ============
 


### PR DESCRIPTION
## Purpose

closes #630 

## Changes

Note: This should be merged after [this](https://github.com/Concordium/concordium-rust-smart-contracts/pull/180) is merged.

- Created a READ.me file in the template folder and linked to it in this documentation (https://github.com/Concordium/concordium-rust-smart-contracts/pull/180). This READ.me includes additional information on the content of the templates and which part of the templates should be customized (e.g. the state of the default template or the logic of the receive function of the default template). 
Several gifs were also added to show what people can do after generating a smart contract project from these templates (e.g. how to test, compile, and simulate an invoke).
- Added additional info to the `compile-module.rst` file about where the user can find the produced `my_module.wasm.v1` module.
- Added additional info to the `setup-contract.rst` file about where the user can get the `state-in.bin` file from.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.