### PR TITLE
Add Concordium's certificate's public key to the the ledger app install guide/download page

### DIFF
--- a/source/mainnet/net/desktop-wallet/install-ledger-app.rst
+++ b/source/mainnet/net/desktop-wallet/install-ledger-app.rst
@@ -1,3 +1,4 @@
+.. include:: ../../variables.rst
 
 .. _install-Ledger-app:
 
@@ -127,9 +128,13 @@ You now have to install a custom certificate on the LEDGER device to ensure that
 
 #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. You can safely ignore the message in the command-line window saying **Broken certificate chain - loading from user key**. This is expected behavior.
 
-#. The certificate is installed on the LEDGER device. The LEDGER device says **Certificate concordium**. Press the right button to navigate through the key, and then press both buttons when the LEDGER device says Trust certificate.
+#. The LEDGER device says **Certificate concordium**. Press the right button to navigate through the key, while confirming that it is the following:
 
-#. Enter your PIN.
+   - :substitution-code:`|ledger-app-public-key|`
+
+and then press both buttons when the LEDGER device says **Trust certificate**.
+
+#. Enter your PIN. The certificate has now been installed on the LEDGER device.
 
 .. _install-ledger-app-windows:
 
@@ -227,9 +232,13 @@ You now have to install a custom certificate to ensure that the LEDGER device tr
 
 #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. You can safely ignore the message in the command-line window saying **Broken certificate chain - loading from user key**. This is expected behavior.
 
-#. The certificate is installed on the LEDGER device. The LEDGER device says **Certificate concordium**. Press the right button to navigate through the key, and then press both buttons when the LEDGER device says **Trust certificate**.
+#. The LEDGER device says **Certificate concordium**. Press the right button to navigate through the key, while confirming that it is the following:
 
-#. Enter your PIN.
+   - :substitution-code:`|ledger-app-public-key|`
+
+and then press both buttons when the LEDGER device says **Trust certificate**.
+
+#. Enter your PIN. The certificate has now been installed on the LEDGER device .
 
 .. _install-ledger-app-macos:
 
@@ -349,7 +358,13 @@ You now have to install a custom certificate to ensure that the LEDGER device tr
 
 #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. You can safely ignore the message in the command-line window saying **Broken certificate chain - loading from user key**. This is expected behavior.
 
-#. The certificate is installed on the LEDGER device. Press the right button to navigate through the key, and then press both buttons when the LEDGER device says **Trust certificate**.
+#. The LEDGER device says **Certificate concordium**. Press the right button to navigate through the key, while confirming that it is the following:
+
+   - :substitution-code:`|ledger-app-public-key|`
+
+and then press both buttons when the LEDGER device says **Trust certificate**.
+
+#. Enter your PIN. The certificate has now been installed on the LEDGER device.
 
 .. _install-ledger-app-ubuntu:
 

--- a/source/mainnet/net/installation/downloads.rst
+++ b/source/mainnet/net/installation/downloads.rst
@@ -95,6 +95,8 @@ Concordium LEDGER App
 
    The LEDGER NANO X is not supported currently.
 
+When installing the certificate, ensure that the public key of the certificate is :substitution-code:`|ledger-app-public-key|` .
+
 - For LEDGER NANO S, `download the Concordium LEDGER App 3.0.1 for LEDGER firmware version 2.1.0 <https://distribution.mainnet.concordium.software/tools/concordium-ledger-app-3.0.1-target-2.1.0.zip>`_
 
 - For LEDGER NANO S PLUS, `download the Concordium LEDGER App 3.0.1 for LEDGER firmware version 1.0.4 <https://distribution.mainnet.concordium.software/tools/concordium-ledger-app-3.0.1-nanos-plus-1.0.4.zip>`_

--- a/source/mainnet/variables.rst
+++ b/source/mainnet/variables.rst
@@ -5,6 +5,7 @@
 .. |cdw-deb-checksum| replace:: ef0237f30e1c435323ef2eff2df82a23ffbb54b7c0b329666a07c78fb61119f1
 .. |cdw-rpm| replace:: concordium-desktop-wallet-1.5.0.rpm
 .. |cdw-rpm-checksum| replace:: 845f375c728b14ce13400869001b58c894510454dd7af8fa95d9538b5d8ef2d4
+.. |ledger-app-public-key| replace:: 04af7e6a68fa79b3f7a035a5cd75f916ee67c4a71fc990fe9ba2b2e1fb54dd7cdc950a73b5a4adf52ea95df16f5c17602090f639f0d35a760e34afae7cbd60792b
 
 .. Mobile Wallet product names
 .. |mw-gen1| replace:: Concordium Legacy Wallet


### PR DESCRIPTION
## Purpose

Display the certificate's public key on the website, so the user can confirm it when adding the certificate to their device.

## Changes

Small adjustments to the ledger install guide. 

## Checklist

- [x] My code follows the style of this project.
- [x]  The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
