### PR TITLE
Mainnet node release March 2023

### DIFF
--- a/source/mainnet/net/installation/downloads-testnet.rst
+++ b/source/mainnet/net/installation/downloads-testnet.rst
@@ -148,8 +148,8 @@ Download cargo-concordium:
 For information about installing `cargo-concordium`, see :ref:`Install tools for development <setup-tools>`.
 
 
-Concordium node distributions v5.2.4
-====================================
+Concordium node distributions
+=============================
 
 For the system requirements to run a node, see :ref:`System requirements to run a node<node-requirements>`.
 
@@ -157,8 +157,8 @@ For the system requirements to run a node, see :ref:`System requirements to run 
 
    When upgrading, you can only upgrade one minor version at a time, or from the last release of major version X to major version X+1. You cannot skip versions. For patches, you can skip versions e.g. X.X.0 to X.X.3, or `X.1.1` to `X.2.3`. To download previous node versions, see :ref:`Previous node versions<previous-downloads>`.
 
-Ubuntu
-------
+Ubuntu v5.2.4
+-------------
 
 To run a node on a server with Ubuntu, you need a Debian package.
 
@@ -168,8 +168,8 @@ To run a node on a server with Ubuntu, you need a Debian package.
 
    To learn how to run a node with Ubuntu, see :ref:`Run a node on a server with Ubuntu <run-node-ubuntu>`.
 
-Linux-Docker
-------------
+Linux-Docker v5.2.4
+-------------------
 
 .. _concordium-docker-package-download-testnet:
 
@@ -177,8 +177,8 @@ To learn how to run a node with Docker, see :ref:`Run a node with Docker <run-a-
 
 To upgrade your Docker node either restart the service if you are using the `:latest` image tag, or change the image tag to the new version. See :ref:`Running/upgrading a node<running-a-node>` for details.
 
-Windows
--------
+Windows v5.2.4
+--------------
 
 To run a node on Windows, you need a Windows Installer package. **Please be aware that you should backup your configuration, as the installer will overwrite the current configuration with a standard configuration.**
 
@@ -186,8 +186,8 @@ To run a node on Windows, you need a Windows Installer package. **Please be awar
 
 To learn how to run a node on Windows, see :ref:`Run and manage a node on Windows <run-node-windows>`.
 
-Mac
----
+Mac v5.2.4
+----------
 
 To run a node on macOS, you need a macOS installer package.
 

--- a/source/mainnet/net/installation/downloads.rst
+++ b/source/mainnet/net/installation/downloads.rst
@@ -146,8 +146,8 @@ Download cargo-concordium:
 
 For information about installing `cargo-concordium`, see :ref:`Install tools for development <setup-tools>`.
 
-Concordium node distributions 5.1.3
-===================================
+Concordium node distributions
+=============================
 
 For the system requirements to run a node, see :ref:`System requirements to run a node<node-requirements>`.
 
@@ -155,20 +155,20 @@ For the system requirements to run a node, see :ref:`System requirements to run 
 
    When upgrading, you can only upgrade one minor version at a time, or from the last release of major version X to major version X+1. You cannot skip versions. For patches, you can skip versions e.g. X.X.0 to X.X.3, or `X.1.1` to `X.2.3`. To download previous node versions, see :ref:`Previous node versions<previous-downloads>`.
 
-Ubuntu
-------
+Ubuntu v5.2.4
+-------------
 
 To run a node on a server with Ubuntu, you need a Debian package.
 
-   - `Download the Mainnet Debian package <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_5.1.3-0_amd64.deb>`_
+   - `Download the Mainnet Debian package <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_5.2.4-0_amd64.deb>`_
 
       - SHA256 checksum of the download: :substitution-code:`|node-deb-package-checksum|`
       - :ref:`Verification instructions <verification-node-debian-package>`
 
    To learn how to run a node with Ubuntu, see :ref:`Run a node on a server with Ubuntu <run-node-ubuntu>`.
 
-Linux-Docker
-------------
+Linux-Docker v5.2.4
+-------------------
 
 .. _concordium-docker-package-download:
 
@@ -176,21 +176,21 @@ To learn how to run a node with Docker, see :ref:`Run a node with Docker <run-a-
 
 To upgrade your Docker node either restart the service if you are using the `:latest` image tag, or change the image tag to the new version. See :ref:`Running/upgrading a node<running-a-node>` for details.
 
-Windows
--------
+Windows v5.2.4
+--------------
 
 To run a node on Windows, you need a Windows Installer package. **Please be aware that you should backup your configuration, as the installer will overwrite the current configuration with a standard configuration.**
 
-   - `Download the Mainnet Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-5.1.3-1.msi>`_
+   - `Download the Mainnet Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-5.2.4-0.msi>`_
 
 To learn how to run a node on Windows, see :ref:`Run and manage a node on Windows <run-node-windows>`.
 
-Mac
----
+Mac v5.2.4
+----------
 
 To run a node on macOS, you need a macOS installer package.
 
-   - `Download the Mainnet macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-5.1.3-1.pkg>`_
+   - `Download the Mainnet macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-5.2.4.pkg>`_
 
 To learn how to run a node on Mac, see :ref:`Run and manage a node on macOS  <run-node-macos>`.
 

--- a/source/mainnet/net/installation/previous-node-downloads.rst
+++ b/source/mainnet/net/installation/previous-node-downloads.rst
@@ -61,6 +61,15 @@ Ubuntu - Mainnet
 Default GRPC port is set to 10000
 Default listen port is set to 8888
 
+`5.1.3 <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_5.1.3-0_amd64.deb>`__
+   - Verification instructions
+
+      In a terminal:
+
+      #. Navigate to the download.
+      #. Paste the following into the terminal: sha256sum concordium-mainnet-node_5.1.3-0_amd64.deb
+      #. Verify that the output matches the SHA256 checksum be10622086fe1225480e68303aab05fcc806150c51327afa7f19c8289600fb6b.
+
 `5.0.6 <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_5.0.6-0_amd64.deb>`__
    - Verification instructions
 

--- a/source/mainnet/net/resources/release-notes-mainnet.rst
+++ b/source/mainnet/net/resources/release-notes-mainnet.rst
@@ -11,6 +11,19 @@ Release notes - Mainnet
 
    To subscribe to updates on the Mainnet status page click **Subscribe** to get all updates or click **Get updates** to choose to get all updates or only updates for specific products.
 
+March 16, 2023
+
+Concordium Node 5.2.4
+---------------------
+
+- The Prometheus metrics exporter has been improved and systematized, making this API stable from this release onwards to monitor your node metrics. The metrics are now `documented <https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md>`_ and the node's Prometheus metrics API stability will adhere to SEMVER guidelines.
+
+- Fixed an issue where the node configuration file (``main.config.json``) was sometimes corrupted.
+
+- Added an option to disable only the node specific grpc V1 endpoints that can be used to control the node. All the endpoints that are consensus related are kept allowing the node to be used as a gateway to the chain. The mentioned endpoints can be disabled by setting ``CONCORDIUM_NODE_DISABLE_RPC_SERVER_NODE_ENDPOINTS`` or using the flag ``--no-rpc-server-node-endpoints``.
+
+- Fixed a bug in ``GetAccountInfo`` endpoint in GRPCv2 where ``incoming_amounts`` field of encrypted amounts was not set correctly.
+
 March 07, 2023
 
 |mw-gen2| for iOS

--- a/source/mainnet/variables.rst
+++ b/source/mainnet/variables.rst
@@ -24,8 +24,8 @@
 
 .. Node debian package verification variables
 
-.. |node-deb-package| replace:: concordium-mainnet-node_5.1.3-0_amd64.deb
-.. |node-deb-package-checksum| replace:: be10622086fe1225480e68303aab05fcc806150c51327afa7f19c8289600fb6b
+.. |node-deb-package| replace:: concordium-mainnet-node_5.2.4-0_amd64.deb
+.. |node-deb-package-checksum| replace:: 579e77a873a46d9a19d058e2c0bacb027efdf46aec8a73cb2983f6d37513be4c
 
 .. Mainnet genesis block verification variables
 .. |mainnet-genesis-block| replace:: genesis.dat


### PR DESCRIPTION
## Purpose

Inform users about the Concordium Mainnet node release 5.2.4 for March.

## Changes

Update previous downloads for Ubuntu, update mainnet release notes, update variables, update downloads for mainnet, adjust downloads for testnet page to remove version number from main heading.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
closes #771 