### PR TITLE
Add Rosetta to list of supported SDKs for grpc2

### DIFF
--- a/source/mainnet/net/references/grpc2.rst
+++ b/source/mainnet/net/references/grpc2.rst
@@ -26,7 +26,7 @@ through an SDK. However the new interface makes it substantially easier to build
 an SDK since there is a canonical schema of responses.
 
 At present the `Concordium Rust SDK
-<https://github.com/Concordium/concordium-rust-sdk>`_ and `Concordium Javascript (Node / Web) SDK <https://github.com/Concordium/concordium-node-sdk-js>`_ have support for the new
+<https://github.com/Concordium/concordium-rust-sdk>`_, `Concordium Javascript (Node / Web) SDK <https://github.com/Concordium/concordium-node-sdk-js>`_, and `Rosetta <https://github.com/Concordium/concordium-rosetta>`__ have support for the new
 interface.
 Other SDKs will be migrated in the future, before the V1
 interface is deprecated.


### PR DESCRIPTION
## Purpose

Inform users that Rosetta now supports grpc v2.

## Changes

Add Rosetta to list of SDKs migrated to grpc v2.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
