### PR TITLE
Fix imports of testing lib in examples

### DIFF
--- a/source/mainnet/smart-contracts/guides/integration-test-contract.rst
+++ b/source/mainnet/smart-contracts/guides/integration-test-contract.rst
@@ -35,7 +35,7 @@ The high-level process of adding integration tests to your existing smart contra
 
    .. code-block:: rust
 
-      use concordium-smart-contract-testing::*;
+      use concordium_smart_contract_testing::*;
 
       #[test]
       fn my_test() { .. }

--- a/source/mainnet/smart-contracts/tutorials/piggy-bank/testing.rst
+++ b/source/mainnet/smart-contracts/tutorials/piggy-bank/testing.rst
@@ -143,7 +143,7 @@ Import the testing library and your contract at the top of the file.
 
 .. code-block:: rust
 
-   use concordium-smart-contract-testing::*;
+   use concordium_smart_contract_testing::*;
    use piggy_bank_part2::*;
 
 Now you can start adding tests to this module.


### PR DESCRIPTION
## Purpose

The imports in the examples are invalid. They should use underscores instead of dashes.

## Changes

- Replace `-` with `_` in imports

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.