### PR TITLE
Add documentation for wCCD

### DIFF
--- a/source/mainnet/net/guides/dapp-examples.rst
+++ b/source/mainnet/net/guides/dapp-examples.rst
@@ -19,7 +19,9 @@ Select an example to see more information about it, such as a hosted dApp for yo
 
 .. dropdown:: wCCD
 
-    `Demo front end <https://wccd.testnet.concordium.com/>`__ where you can try the functionality on Concordium's testnet
+    `Demo front end testnet <https://wccd.testnet.concordium.com/>`__ where you can try the functionality on Concordium's testnet
+
+    `Demo front end mainnet <https://wccd.mainnet.concordium.software/>`__ where you can try the functionality on Concordium's mainnet
 
     :ref:`Tutorial about the wCCD smart contract and dApp<wCCD>`.
 

--- a/source/mainnet/smart-contracts/onboarding-guide-ethereum-developers/faq.rst
+++ b/source/mainnet/smart-contracts/onboarding-guide-ethereum-developers/faq.rst
@@ -593,11 +593,11 @@ Standards
     - the :ref:`wCCD tutorial<wCCD>`
     - the wCCD example `source code <https://github.com/Concordium/concordium-rust-smart-contracts/blob/main/examples/cis2-wccd/src/lib.rs>`_.
 
-    Concordium provides and maintains the canonical wCCD implementation on testnet; mainnet implementation is coming soon.
+    Concordium provides and maintains the canonical wCCD implementation.
     Developers are encouraged to use the following addresses for their dApps.
 
     - Testnet canonical wCCD address: |wccd-address-testnet|
-    - Mainnet canonical wCCD address: coming soon
+    - Mainnet canonical wCCD address: |wccd-address-mainnet|
 
 .. dropdown:: Does Concordium have upgradable smart contracts?
 

--- a/source/mainnet/smart-contracts/onboarding-guide-solana-developers/faq.rst
+++ b/source/mainnet/smart-contracts/onboarding-guide-solana-developers/faq.rst
@@ -575,11 +575,11 @@ Standards
     - the :ref:`wCCD tutorial<wCCD>`
     - the wCCD example `source code <https://github.com/Concordium/concordium-rust-smart-contracts/blob/main/examples/cis2-wccd/src/lib.rs>`_.
 
-    Concordium provides and maintains the canonical wCCD implementation on testnet; mainnet implementation is coming soon.
+    Concordium provides and maintains the canonical wCCD implementation.
     Developers are encouraged to use the following addresses for their dApps.
 
     - Testnet canonical wCCD address: |wccd-address-testnet|
-    - Mainnet canonical wCCD address: coming soon
+    - Mainnet canonical wCCD address: |wccd-address-mainnet|
 
 .. dropdown:: Does Concordium have upgradable smart contracts?
 

--- a/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-full-dApp.rst
+++ b/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-full-dApp.rst
@@ -6,7 +6,7 @@ Running your first full dApp
 ============================
 
 You are running your own local dApp now. If you want, you can compare it with our
-`wCCD dApp <https://wccd.testnet.concordium.com/>`_ hosted on testnet. You can use your |bw|
+`testnet wCCD dApp <https://wccd.testnet.concordium.com/>`_ hosted on testnet or `mainnet wCCD dApp <https://wccd.mainnet.concordium.software/>`_ hosted on mainnet. You can use your |bw|
 to connect to the dApp.
 
 .. note::

--- a/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-introduction.rst
+++ b/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-introduction.rst
@@ -1,3 +1,5 @@
+.. include:: ../../../variables.rst
+
 .. _wCCD-introduction:
 
 =====================================
@@ -64,12 +66,12 @@ newest science and research done at Concordium. The protocol is free of charge a
 The canonical wCCD smart contract following the ``CIS-2`` standard
 is deployed on ``testnet`` at the following addresses:
 
-``wCCD (Testnet):`` **{ index: 2059, subindex: 0 }**
+``wCCD (Testnet):`` |wccd-address-testnet|
 
 The canonical wCCD smart contract following the ``CIS-2`` standard is
 deployed on ``mainnet`` at the following addresses:
 
-``wCCD (Mainnet):`` **{ index: 9354, subindex: 0 }**
+``wCCD (Mainnet):`` |wccd-address-mainnet|
 
 .. note::
 

--- a/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-introduction.rst
+++ b/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-introduction.rst
@@ -69,12 +69,7 @@ is deployed on ``testnet`` at the following addresses:
 The canonical wCCD smart contract following the ``CIS-2`` standard is
 deployed on ``mainnet`` at the following addresses:
 
-.. note::
-
-    Deployment on mainnet will follow once a partner has been chosen to manage the deployment.
-
-
-``wCCD (Mainnet):`` coming soon
+``wCCD (Mainnet):`` **{ index: 9354, subindex: 0 }**
 
 .. note::
 

--- a/source/mainnet/variables.rst
+++ b/source/mainnet/variables.rst
@@ -36,3 +36,4 @@
 
 .. Canonical smart contract instances
 .. |wccd-address-testnet| replace:: <2059,0>
+.. |wccd-address-mainnet| replace:: <9354,0>


### PR DESCRIPTION
## Purpose

- Add the canonical smart contract index for wCCD to the documentation. Update front-end URLs that link to the mainnet wCCD front end.

## Changes

Note: This should be only merged once the wCCD front end for mainnet is deployed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
