### PR TITLE
Add concordium academy when deploying

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -34,11 +34,20 @@ jobs:
         shell: bash
         run: ./scripts/build.sh
 
-      - name: Deploy preview 🚀
+      - name: Deploy preview for Developer Documentation 🚀
         uses: rossjrw/pr-preview-action@v1
         with:
           preview-branch: gh-pages
           umbrella-dir: pr-preview
           custom-url: developer.concordium.software
           source-dir: ./build
+          action: deploy
+
+      - name: Deploy preview for Concordium Academy 🚀
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview-academy
+          custom-url: developer.concordium.software
+          source-dir: ./build-academy
           action: deploy

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -34,15 +34,6 @@ jobs:
         shell: bash
         run: ./scripts/build.sh
 
-      - name: Deploy preview for Developer Documentation 🚀
-        uses: rossjrw/pr-preview-action@v1
-        with:
-          preview-branch: gh-pages
-          umbrella-dir: pr-preview
-          custom-url: developer.concordium.software
-          source-dir: ./build
-          action: deploy
-
       - name: Deploy preview for Concordium Academy 🚀
         uses: rossjrw/pr-preview-action@v1
         with:
@@ -50,4 +41,13 @@ jobs:
           umbrella-dir: pr-preview-academy
           custom-url: developer.concordium.software
           source-dir: ./build-academy
+          action: deploy
+
+      - name: Deploy preview for Developer Documentation 🚀
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          custom-url: developer.concordium.software
+          source-dir: ./build
           action: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
         run: ./scripts/build.sh
 
-      - name: Deploy 🚀
+      - name: Deploy Developer Documentation 🚀
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: gh-pages
@@ -36,4 +36,15 @@ jobs:
           # Prevent the default behavior of force pushing which will remove previews see https://github.com/marketplace/actions/deploy-pr-preview.
           force: false
           clean: true
-          clean-exclude: pr-preview/
+          clean-exclude: |
+            pr-preview/
+            pr-preview-academy/
+
+      - name: Deploy Concordium Academy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          branch: gh-pages
+          repository-name: Concordium/concordium-academy
+          ssh-key: ${{ secrets.CONCORDIUM_ACADEMY_DEPLOY_KEY }}
+          folder: build-academy
+          clean: true

--- a/.github/workflows/remove-preview.yml
+++ b/.github/workflows/remove-preview.yml
@@ -14,11 +14,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Remove preview
+      - name: Remove preview for Developer Documentation
         uses: rossjrw/pr-preview-action@v1
         with:
           preview-branch: gh-pages
           umbrella-dir: pr-preview
           source-dir: ./build
+          action: remove
+
+      - name: Remove preview for Concordium Academy
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview-academy
+          source-dir: ./build-academy
           action: remove
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build-academy/
 __pycache__
 _build
 /source/.vscode/

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ extension](https://www.sphinx-doc.org/en/master/usage/extensions/graphviz.html).
 
 ## Development
 
-All of the documentation lives in the `source` directory; here there is a subdirectory for Mainnet. General content such as site images, stylesheets, and other templates are in the `source` directory.
+All of the documentation lives in the `source` directory; here there is a subdirectory `mainnet` for the developer document and a subdirectory `academy` for Concordium Academy.
+General content such as site images, stylesheets, and other templates are in the `source` directory.
 
 ## Installation
 
@@ -150,6 +151,14 @@ To generate the schemas:
 branch of Concordium Rust
 SDK](https://github.com/Concordium/concordium-rust-sdk/tree/derive-schema).
 2. Run `cargo run generate --output_folder <path-to-grpc-json-schema-folder>`.
+
+# Deployment
+
+The developer documentation is hosted by GitHub Pages and the released files can be viewed on the branch [`gh-pages`](https://github.com/Concordium/concordium.github.io/tree/gh-pages).
+Likewise for the Concordium Academy site, the released files can be viewed on the [`gh-pages`](https://github.com/Concordium/concordium-academy/tree/gh-pages) branch of the [Concordium/concordium-academy repository](https://github.com/Concordium/concordium-academy).
+
+Deployment is triggered manually using the [Deploy workflow](https://github.com/Concordium/concordium.github.io/actions/workflows/deploy.yml) in GitHub Actions of this repository.
+This will build and deploy both the developer documentation and Concordium Academy.
 
 # Contributing
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,45 +1,35 @@
 #!/bin/bash
 
-# Builds the different versions and translations of the documentation.
+# Build the developer documentation and the Concordium Academy.
 # This is assumed to be called from the project root.
 
 set -e # Fail script on error
 
-# Documentation projects to include in the build, must be separated by comma and no spaces.
-all_projects='mainnet,academy'
-
-# Languages to include in the build
-all_languages='en'
+printf "Building Concordium Developer Documentation... \n\n"
 
 source_dir='source'
 build_dir='build'
-
-# Expose settings for the build to create links between them
-export all_projects
-export all_languages
-
-# Convert the strings to arrays
-IFS="," read -a projects <<< $all_projects
-IFS="," read -a languages <<< $all_languages
-
-printf "Building documentation versions: ${all_projects} for languages ${all_languages}\n"
 
 mkdir -p "${build_dir}"
 
 printf "Copying 'public' to '${build_dir}'\n"
 cp -rv public/* ${build_dir}
 
-for current_project in ${projects[@]}; do
-  printf "\nProject '${current_project}':\n-----------------------------\n"
-  export current_version
+printf "\nRunning build 'mainnet'\n"
+sphinx-build "${source_dir}/mainnet" "${build_dir}/en/mainnet" -W
 
-  for current_language in ${languages[@]}; do
-    export current_language
-    printf "\nRunning build '${current_project}' for language '${current_language}'\n"
-    sphinx-build "${source_dir}/${current_project}" "${build_dir}/${current_language}/${current_project}" -D language="${current_language}" -W
-  done
+printf "Adding symlink ${build_dir}/404.html to en/mainnet/404.html\n"
+ln -sf "en/mainnet/404.html" "${build_dir}/404.html"
 
-printf "Adding symlink ${build_dir}/404.html to ${languages[0]}/${projects[0]}/404.html\n"
-ln -sf "${languages[0]}/${projects[0]}/404.html" "${build_dir}/404.html"
+printf "\nDone building Concordium Developer Documentation to '${build_dir}'\n"
 
-done
+
+# Build Concordium Academy, depends on objects.inv produce by mainnet for checking links.
+printf "\nBuilding Concordium Academy... \n\n"
+
+academy_build_dir='build-academy'
+
+mkdir -p "${academy_build_dir}"
+sphinx-build "${source_dir}/academy" "${academy_build_dir}" -W
+
+printf "Done building Concordium Academy to '${academy_build_dir}'\n"


### PR DESCRIPTION
## Purpose

Deploy Concordium Academy together with the developer documentation.
This will make the Deploy action also build and deploy Concordium Academy.
Likewise, adding preview label causes a preview of Concordium Academy to be built.

## Changes

- Simplify build script and add Concordium academy.
- Make the 'Deploy' action include deployment of Concordium Academy.
- Generated and added keys to allow for deployment to https://github.com/Concordium/concordium-academy
