### PR TITLE
Adjust font settings

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -27,7 +27,7 @@
     --pst-color-inline-code: 178, 34, 34;
     --primary-color: #302AE6;
     --secondary-color: #536390;
-    --font-color: #000000;
+    --font-color: #333333;
     --bg-color: #fff;
     --heading-color: #292922;
 }
@@ -53,7 +53,8 @@ body{
   }
 
 p{
-    line-height: 30px;
+    line-height: 1.7em;
+    font-size: 17px;
     color: var(--font-color);
     font-family: var(--pst-font-family-base-system);
 }


### PR DESCRIPTION
## Purpose

Since documentation is text-heavy, I think it would benefit from bigger font size and a font color slightly lighter than black.

## Changes

**Before**
![before](https://github.com/Concordium/concordium.github.io/assets/6437768/1ca01f46-0dc8-4a21-91ce-317277fcacf0)

**After**
![after](https://github.com/Concordium/concordium.github.io/assets/6437768/4cc33033-720c-435e-8c9c-28db6d5d4dfa)
