### PR TITLE
Fix typos in PyggyBank tutorial

### DIFF
--- a/source/mainnet/smart-contracts/tutorials/piggy-bank/testing.rst
+++ b/source/mainnet/smart-contracts/tutorials/piggy-bank/testing.rst
@@ -129,7 +129,7 @@ The library requires the Rust edition ``2021`` or greater, which you must also s
    edition = "2021"
 
    [dev-dependencies]
-   concordium-smart-contract-testing = "1.0"
+   concordium-smart-contract-testing = "3.0"
 
 Add a test module
 =================
@@ -260,7 +260,7 @@ Going back to your test case, use the function |module_load_v1|_ to load the mod
    #[test]
    fn test_init() {
        // .. lines omitted for brevity.
-       let module = load_module_v1("piggy_bank_part2.wasm.v1").expect("Module is valid and exists");
+       let module = module_load_v1("piggy_bank_part2.wasm.v1").expect("Module is valid and exists");
    }
 
 |module_load_v1|_ attempts to load a module from disk, which might be missing or invalid, and it thus returns a ``Result`` type.
@@ -284,7 +284,7 @@ In this tutorial, you will always use a |Signer|_ with one key as that is the mo
    fn test_init() {
        let mut chain = Chain::new();
        // .. lines omitted for brevity.
-       let module = load_module_v1("piggy_bank_part2.wasm.v1").expect("Module is valid and exists");
+       let module = module_load_v1("piggy_bank_part2.wasm.v1").expect("Module is valid and exists");
        let deployment = chain
            .module_deploy_v1(
                Signer::with_one_key(),
@@ -503,7 +503,7 @@ You can then verify the success of the update and the contract balance:
        // .. Lines omitted for brevity.
 
        assert!(update.is_ok(), "Inserting into intact piggy bank failed");
-       assert!(
+       assert_eq!(
            chain.contract_balance(initialization.contract_address),
            Some(insert_amount),
            "Piggy bank balance does not match amount inserted"
@@ -547,7 +547,7 @@ The second test becomes:
            );
 
        assert!(update.is_ok(), "Inserting into intact piggy bank failed");
-       assert!(
+       assert_eq!(
            chain.contract_balance(initialization.contract_address),
            Some(insert_amount)
            "Piggy bank balance does not match amount inserted"


### PR DESCRIPTION
## Purpose

Fix some typos in the PyggyBank testing tutorial.