### PR TITLE
Remove references to JSON-RPC in documentation

### DIFF
--- a/source/mainnet/smart-contracts/tutorials/voting/voting-dapp.rst
+++ b/source/mainnet/smart-contracts/tutorials/voting/voting-dapp.rst
@@ -39,7 +39,7 @@ need for the user to host their own Concordium node.
 
 A web wallet is a piece of code that can be added as an extension to supported browsers such as ``Chrome``.
 The web wallet allows you to interact with the chain and make transactions.
-Currently, the |bw| does this by connecting to a (JSON-RPC) server that communicates with a node.
+Currently, the |bw| does this by connecting to a (gRPC) server that communicates with a node.
 The |bw| hosts the private keys corresponding to the accounts of the user and a link that points
 to a `server  <https://github.com/Concordium/concordium-json-rpc>`_.
 

--- a/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-front-end-set-up.rst
+++ b/source/mainnet/smart-contracts/tutorials/wCCD/wCCD-front-end-set-up.rst
@@ -39,7 +39,7 @@ need for the user to host their own Concordium node.
 
 A browser wallet is a piece of code that can be added as an extension to supported browsers such as ``Chrome``.
 The browser wallet allows you to interact with the chain and make transactions.
-Currently, the |bw| does this by connecting to a (JSON-RPC) server that communicates with a node.
+Currently, the |bw| does this by connecting to a (gRPC) server that communicates with a node.
 The |bw| hosts the private keys corresponding to the accounts of the user and a link that points
 to a `server  <https://github.com/Concordium/concordium-json-rpc>`_.
 


### PR DESCRIPTION
## Purpose

JSON RPC is deprecated (or nearly so) and references should be removed.

## Changes

Front-end setup for wCCD and voting in tutorials.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
