### PR TITLE
Correct iOS 1.2.0 release date

### DIFF
--- a/source/mainnet/net/release-notes/release-notes-lp.rst
+++ b/source/mainnet/net/release-notes/release-notes-lp.rst
@@ -19,7 +19,7 @@ Wallets
 |mw-gen2| for iOS
 -----------------
 
-    September 9, 2023
+    October 9, 2023
 
         Version 1.2.0 includes support to manage fungible and non-fungible tokens. This includes adding, inspecting, and removing tokens.
 


### PR DESCRIPTION
## Purpose

1.2.0 release date still said September.

## Changes

Changed to October

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
