### PR TITLE
Moved Deploy academy to workflow in concordium-academy repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,17 +39,3 @@ jobs:
           clean-exclude: |
             pr-preview/
             pr-preview-academy/
-
-      - name: Install SSH Client 🔑
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.CONCORDIUM_ACADEMY_DEPLOY_KEY }}
-
-      - name: Deploy Concordium Academy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
-        with:
-          repository-name: Concordium/concordium-academy
-          branch: gh-pages
-          ssh-key: true
-          folder: build-academy
-          clean: true

--- a/README.md
+++ b/README.md
@@ -158,7 +158,10 @@ The developer documentation is hosted by GitHub Pages and the released files can
 Likewise for the Concordium Academy site, the released files can be viewed on the [`gh-pages`](https://github.com/Concordium/concordium-academy/tree/gh-pages) branch of the [Concordium/concordium-academy repository](https://github.com/Concordium/concordium-academy).
 
 Deployment is triggered manually using the [Deploy workflow](https://github.com/Concordium/concordium.github.io/actions/workflows/deploy.yml) in GitHub Actions of this repository.
-This will build and deploy both the developer documentation and Concordium Academy.
+This will build both the developer documentation and the Concordium Academy site, to ensure that links used by Academy are still valid. But only deploy the the developer documentation.
+
+To deploy the Concordium Academy site trigger the [Deploy workflow](https://github.com/Concordium/concordium-academy/actions/workflows/deploy.yml) in GitHub Actions of [`Concordium/concordium-academy`](https://github.com/Concordium/concordium-academy).
+This workflow will clone this repository, build and only deploy the Academy site.
 
 # Contributing
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,7 @@
-# Tell crawlers to ignore PR preview builds.
+# Tell crawlers to ignore PR preview builds for the Developer Documentation.
 User-agent: *
 Disallow: /pr-preview/
+
+# Tell crawlers to ignore PR preview builds for the Concordium Academy site.
+User-agent: *
+Disallow: /pr-preview-academy/

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,8 +23,8 @@ ln -sf "en/mainnet/404.html" "${build_dir}/404.html"
 
 printf "\nDone building Concordium Developer Documentation to '${build_dir}'\n"
 
-
 # Build Concordium Academy, depends on objects.inv produce by mainnet for checking links.
+# This will also ensure that links to the documentation used by the Academy site are still valid.
 printf "\nBuilding Concordium Academy... \n\n"
 
 academy_build_dir='build-academy'


### PR DESCRIPTION
## Purpose

Remove Academy deployment, since this is now a workflow in `concordium-academy` repo.

## Changes

- Remove steps to deploy academy site from the Deploy workflow.
- Update deployment section of readme.md.
- Disallow web-crawlers from the academy previews.
