### PR TITLE
Remove stray instances of old grpc port numbers

### DIFF
--- a/source/mainnet/net/desktop-wallet/accounts-desktop.rst
+++ b/source/mainnet/net/desktop-wallet/accounts-desktop.rst
@@ -116,9 +116,9 @@ Node settings
 
 Here you specify which node on the blockchain that you want to connect to.
 
-- If you're running the **mainnet** version of the Desktop Wallet, you must connect to a mainnet node. In the **Address field**, enter ``127.0.0.1`` and in the **Port field** enter ``10000``.
+- If you're running the **mainnet** version of the Desktop Wallet, you must connect to a mainnet node. In the **Address field**, enter ``127.0.0.1`` and in the **Port field** enter ``20000``.
 
-- If you're running the **testnet** version of the Desktop Wallet, you must connect to a testnet node. In the **Address** field, enter ``127.0.0.1`` and in the **Port field** enter ``10001``.
+- If you're running the **testnet** version of the Desktop Wallet, you must connect to a testnet node. In the **Address** field, enter ``127.0.0.1`` and in the **Port field** enter ``20001``.
 
 - Select **Set connection**. If the connection works, there's a message saying **Successfully connected**.
 

--- a/source/mainnet/net/guides/become-baker.rst
+++ b/source/mainnet/net/guides/become-baker.rst
@@ -327,7 +327,7 @@ Use ``validator configure`` to configure a validator and open a staking pool. Th
 
 .. code-block:: console
 
-   $concordium-client validator configure --sender "acc1" --stake 500001 --open-delegation-for existing --delegation-transaction-fee-commission 0.1 --delegation-baking-commission 0.1 --delegation-finalization-commission 1.0 --validator-url https://example.com/validator --keys-in MyBakerKeys.json --keys-out <concordium-data-dir>/validator-credentials.json
+   $concordium-client validator configure --sender "acc1" --stake 500001 --open-delegation-for existing --delegation-transaction-fee-commission 0.1 --delegation-block-reward-commission 0.1 --validator-url https://example.com/validator --keys-in MyBakerKeys.json --keys-out <concordium-data-dir>/validator-credentials.json
 
 Configure validator has the following optional arguments:
 
@@ -340,8 +340,7 @@ Configure validator has the following optional arguments:
 - ``--keys-in`` specifies the name of the file containing the validator keys.
 - ``--keys-out`` can be used to write a validator credential file containing the validator ID (and the supplied keys) to use when starting a validator node. Replace ``<concordium-data-dir>`` with any path of your choice.
 - ``--delegation-transaction-fee-commission`` specifies the transaction fee commission for the staking pool.
-- ``--delegation-baking-commission`` specifies the validator commission for the staking pool.
-- ``--delegation-finalization-commission`` specifies the finalization commission for the staking pool.
+- ``--delegation-block-reward-commission`` specifies the block commission for the staking pool.
 
 .. Note::
 

--- a/source/mainnet/net/guides/overview-desktop.rst
+++ b/source/mainnet/net/guides/overview-desktop.rst
@@ -32,9 +32,9 @@ Before you start, make sure you’ve completed the following steps:
 
     #. If this is the first time you're opening the Desktop Wallet, you're asked to connect to a node. If you don't see this message, go to **Settings**, and then select **Node settings**. The Virtual Hive node (concordiumwalletnode.com) is inserted by default, but you can change this to any other node that you prefer or the node provided by your third-party provider. Enter the **Address** and **Port** of the node you’re running. The address is the network address of the node.
 
-    - If you're running the mainnet version of the Desktop Wallet, you must connect to a mainnet node. In the **Address field**, enter *127.0.0.1*, and in the **Port field** enter *10000*.
+    - If you're running the mainnet version of the Desktop Wallet, you must connect to a mainnet node. In the **Address field**, enter *127.0.0.1*, and in the **Port field** enter *20000*.
 
-    - If you're running the testnet version of the Desktop Wallet, you must connect to a testnet node. In the **Address** field, enter *127.0.0.1*, and in the **Port field** enter *10001*.
+    - If you're running the testnet version of the Desktop Wallet, you must connect to a testnet node. In the **Address** field, enter *127.0.0.1*, and in the **Port field** enter *20001*.
 
         .. image:: ../images/run-node/Node-setup-win-9.png
             :width: 60%

--- a/source/mainnet/net/guides/run-node-macos.rst
+++ b/source/mainnet/net/guides/run-node-macos.rst
@@ -166,9 +166,9 @@ You can also verify that a node is running by connecting it to the Desktop Walle
 
 #. In the Desktop Wallet, go to **Settings**, and then select **Node settings**.
 
-   - If you're running the **mainnet** version of the Desktop Wallet, you must connect to a mainnet node. In the **Address field**, enter ``127.0.0.1`` and in the **Port field** enter ``10000``.
+   - If you're running the **mainnet** version of the Desktop Wallet, you must connect to a mainnet node. In the **Address field**, enter ``127.0.0.1`` and in the **Port field** enter ``20000``.
 
-   - If you're running the **testnet** version of the Desktop Wallet, you must connect to a testnet node. In the **Address field**, enter ``127.0.0.1`` and in the **Port field** enter ``10001``.
+   - If you're running the **testnet** version of the Desktop Wallet, you must connect to a testnet node. In the **Address field**, enter ``127.0.0.1`` and in the **Port field** enter ``20001``.
 
 #. Select **Set connection**. If the connection works and the node is running properly, there’s a message saying *Successfully connected*.
 

--- a/source/mainnet/net/guides/run-node-windows.rst
+++ b/source/mainnet/net/guides/run-node-windows.rst
@@ -148,9 +148,9 @@ You can also verify that a node is running by connecting it to the Desktop Walle
 
 #. In the Desktop Wallet, go to **Settings**, and then select **Node settings**.
 
-   - If you're running the mainnet version of the Desktop Wallet, you must connect to a mainnet node. In the **Address field**, enter *127.0.0.1* and in the **Port field** enter *10000*.
+   - If you're running the mainnet version of the Desktop Wallet, you must connect to a mainnet node. In the **Address field**, enter *127.0.0.1* and in the **Port field** enter *20000*.
 
-   - If you're running the testnet version of the Desktop Wallet, you must connect to a testnet node. In the **Address** field, enter *127.0.0.1* and in the **Port field** enter *10001*.
+   - If you're running the testnet version of the Desktop Wallet, you must connect to a testnet node. In the **Address** field, enter *127.0.0.1* and in the **Port field** enter *20001*.
 
      .. image:: ../images/run-node/Node-setup-win-9.png
          :width: 60%

--- a/source/mainnet/net/guides/run-node.rst
+++ b/source/mainnet/net/guides/run-node.rst
@@ -357,7 +357,6 @@ The main differences from the testnet configuration are:
   <https://hub.docker.com/r/concordium/mainnet-node>`_
   for a list of currently available versions.
 - the node listens on port 8888 instead of 8889 by default
-- the node's GRPC interface is exposed on port 10000 instead of 10001
 - the node’s GRPC V2 listens on port 20000 instead of 20001
 - the database directory is ``/var/lib/concordium-mainnet`` instead of
   ``/var/lib/concordium-testnet``
@@ -401,10 +400,6 @@ To retrieve mainnet node logs run:
          - CONCORDIUM_NODE_CONNECTION_DESIRED_NODES=5
          # Maximum number of __nodes__ the node will be connected to.
          - CONCORDIUM_NODE_CONNECTION_MAX_ALLOWED_NODES=10
-         # Address of the GRPC server
-         - CONCORDIUM_NODE_RPC_SERVER_ADDR=0.0.0.0
-         # And its port
-         - CONCORDIUM_NODE_RPC_SERVER_PORT=10000
          # Address of the V2 GRPC server.
          - CONCORDIUM_NODE_GRPC2_LISTEN_ADDRESS=0.0.0.0
          # And its port which has to be the same as in `CONCORDIUM_NODE_COLLECTOR_GRPC_HOST`
@@ -438,7 +433,6 @@ To retrieve mainnet node logs run:
        # the node's gRPC interface will not be available from the host.
        ports:
        - "8888:8888"
-       - "10000:10000"
        - "20000:20000"
        volumes:
        # The node's database should be stored in a persistent volume so that it

--- a/source/mainnet/net/installation/previous-node-downloads.rst
+++ b/source/mainnet/net/installation/previous-node-downloads.rst
@@ -86,7 +86,7 @@ macOS - Mainnet and Testnet
 Ubuntu - Mainnet
 ================
 
-Default GRPC port is set to 10000
+Default GRPC port is set to 20000
 Default listen port is set to 8888
 
 `6.0.4 <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_6.0.4-0_amd64.deb>`__
@@ -209,7 +209,7 @@ Default listen port is set to 8888
 Ubuntu - Testnet
 ================
 
-Default GRPC port is set to 10001
+Default GRPC port is set to 20001
 Default listen port is set to 8889
 
 `6.1.7 <https://distribution.testnet.concordium.com/deb/concordium-testnet-node_6.1.7-0_amd64.deb>`__

--- a/source/mainnet/net/nodes/node-runner-service-configuration.rst
+++ b/source/mainnet/net/nodes/node-runner-service-configuration.rst
@@ -124,9 +124,9 @@ rpc.port
 
 .. code-block:: TOML
 
-   rpc.port = 10000
+   rpc.port = 20000
 
-The port on which the node accepts incoming GRPC requests. This is the port that the desktop wallet and ``concordium-client`` use to connect to the node. If not specified, this uses the default determined by ``concordium-node.exe`` (which is **10000**). Note that multiple nodes cannot listen on the same port, and a node will fail to start if the port is already in use.
+The port on which the node accepts incoming GRPC requests. This is the port that the desktop wallet and ``concordium-client`` use to connect to the node. If not specified, this uses the default determined by ``concordium-node.exe`` (which is **20000**). Note that multiple nodes cannot listen on the same port, and a node will fail to start if the port is already in use.
 
 rpc.address
 -----------


### PR DESCRIPTION
## Purpose

Fixing an open support issue where a user was trying to use the old grpc port number.

## Changes

Remove or change references to the old grpc port numbers

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
