### PR TITLE
Fix missing command in NFT minting tutorial

### DIFF
--- a/source/mainnet/smart-contracts/tutorials/nft-minting/mint-xfer.rst
+++ b/source/mainnet/smart-contracts/tutorials/nft-minting/mint-xfer.rst
@@ -29,14 +29,15 @@ With a text editor open up that file and place your account address and token ID
         "tokens": ["00000111"]
     }
 
+Then run the command below to invoke the mint function with the given params.
+
+.. code-block:: console
+
+    concordium-client contract update <YOUR-CONTRACT-INSTANCE> --entrypoint mint --parameter-json nft-artifacts/nft-params.json --schema dist/smart-contract-multi/schema.bin --sender <YOUR-ADDRESS> --energy 6000 --grpc-port 20001
+
 Minting is successful.
 
 .. image:: images/mint-success.png
-    :width: 100%
-
-You can also check the dashboard to see the status of your operation in a more visual way. To do that, use the transaction status hash from your terminal.
-
-.. image:: images/mint-result-db.png
     :width: 100%
 
 .. _nft-view-fn:


### PR DESCRIPTION
## Purpose

The command to mint was missing in the tutorial.

## Changes

Added the command and removed screenshot from now deprecated dashboard.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
