### PR TITLE
Add link to discord bot in Concordia

### DIFF
--- a/source/mainnet/conf.py
+++ b/source/mainnet/conf.py
@@ -15,7 +15,6 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-import sphinx_rtd_theme
 import sys, os
 
 sys.path.append(os.path.abspath('../exts'))

--- a/source/mainnet/conf.py
+++ b/source/mainnet/conf.py
@@ -41,7 +41,7 @@ release = ''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx_rtd_theme",
+    #"sphinx_rtd_theme",
     "sphinx.ext.todo",
     "sphinx.ext.graphviz",
     "sphinx.ext.intersphinx",

--- a/source/mainnet/net/web3-id/concordia.rst
+++ b/source/mainnet/net/web3-id/concordia.rst
@@ -35,6 +35,7 @@ To verify that you are using the real Concordium bots configured in our channels
 Telegram - Mainnet - @ConcordiaWeb3IDBot
 
 Discord- Mainnet - Concordia#0667
+You can use `this link for Discord <https://discord.com/api/oauth2/authorize?client_id=1149262289619402842&permissions=3072&scope=bot+applications.commands>`__ to invite this bot to your server.
 
 There is an example of independent issuers with the user interface that can be used to issue verifiable credentials for the account that is owned on the social media network. After verifiable credentials are issued, they can be used to prove ownership of social media accounts and transfer trust between them by using Concordia social media verifier on `Testnet <https://concordia.testnet.concordium.com/>`__ or `Mainnet <https://concordia.mainnet.concordium.software/>`__.
 


### PR DESCRIPTION
## Purpose

Add a link to the Discord Concordia bot in the documentation.

## Changes

(Fix unrelated issue in conf.py)
Add link to the Concordia bot for Discord in concordia.rst

## Checklist

- [X] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
