### PR TITLE
Fix broken CI

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,4 +20,4 @@ doc8 = "*"
 sphinx-autobuild = "*"
 
 [requires]
-python_version = "3.11"
+python_version = "3.12"


### PR DESCRIPTION
The jobs are currently failing due to a mismatch in Python versions.

The reason is that we implicitly use the latest `sphinxdoc/sphinx` image while relying on a specific version of Python being available. It might be a good idea to pin the docker image versions to avoid surprises like this in the future.