### PR TITLE
Fix Readme pipenv command for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Download and run the launcher. Make sure to select "Add Python to PATH" at the b
 After that from a terminal run
 ```
 pip3 install pipenv
-pipenv sync
+pipenv sync --dev
 ```
 from the root of this repository.
 


### PR DESCRIPTION
## Purpose

Fix Readme pipenv command for Windows, so the site works on Windows.

## Changes

- Add `--dev` argument for `pipeenv` as suggested by @td202 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
