### PR TITLE
Imporved voting tutorial, removed unnecessary wallet info

### DIFF
--- a/source/mainnet/tutorials/voting/voting-dapp.rst
+++ b/source/mainnet/tutorials/voting/voting-dapp.rst
@@ -58,60 +58,6 @@ To continue the tutorial, we'll need to install the |bw|. Install the extension 
 
 The wallet connects to a server hosted by Concordium which will take care of the Concordium node on your behalf.
 
-Start the browser wallet by clicking on the Concordium icon at the top right of the Chrome browser.
-
-.. image:: ../wCCD/images/wCCD_tutorial_18.png
-    :width: 100 %
-
-.. note::
-
-    The puzzle icon at the top right of Google Chrome allows you to manage your browser extensions.
-    Here, you can enable pinning of the wallet extension to always have it handy.
-
-    .. image:: ../wCCD/images/wCCD_tutorial_13.png
-        :width: 30 %
-
-Create a new account on testnet by going through the setup steps.
-You have to choose a password to secure the wallet.
-This password is needed to log in to the wallet.
-
-.. image:: ../wCCD/images/wCCD_tutorial_15.png
-    :width: 30 %
-
-The wallet creates a unique secret recovery phrase. Write down the secret recovery phrase
-and keep it in a safe place to be able to recover your accounts in case
-you lose access to your device.
-
-You have now completed the setup. Please verify that your wallet is connected to the Concordium Testnet.
-
-.. image:: ../wCCD/images/wCCD_tutorial_16.png
-    :width: 30 %
-
-.. image:: ../wCCD/images/wCCD_tutorial_17.png
-    :width: 30 %
-
-Before you can create a new account, you need to create an identity. You can do this easily on testnet via the Concordium testnet ID provider.
-
-.. image:: ../wCCD/images/wCCD_tutorial_19.png
-    :width: 30 %
-
-.. image:: ../wCCD/images/wCCD_tutorial_20.png
-    :width: 30 %
-
-.. image:: ../wCCD/images/wCCD_tutorial_21.png
-    :width: 30 %
-
-.. image:: ../wCCD/images/wCCD_tutorial_22.png
-    :width: 30 %
-
-Finally, create a new account on testnet.
-
-.. image:: ../wCCD/images/wCCD_tutorial_19.png
-    :width: 30 %
-
-.. image:: ../wCCD/images/wCCD_tutorial_20.png
-    :width: 30 %
-
 For testing you'll need some CCD in your account. Send some CCD to your new account or request some CCD from the :ref:`testnet faucet button<testnet-faucet>` within the wallet.
 Check that your account balance is displayed and you have enough
 CCD to be able to execute transactions.
@@ -122,8 +68,6 @@ CCD to be able to execute transactions.
 
 .. image:: ../wCCD/images/wCCD_tutorial_14.png
     :width: 40 %
-
-You can find more information on how to set up the wallet in :ref:`Setup the Concordium Wallet for Web<setup-browser-wallet>`.
 
 Running the web frontend
 -------------------------

--- a/source/mainnet/tutorials/voting/voting-sc.rst
+++ b/source/mainnet/tutorials/voting/voting-sc.rst
@@ -29,9 +29,6 @@ Basic setup
 The source code of your smart contract is going to be in the ``src`` directory, which already contains the file ``lib.rs``, assuming you follow the above guide
 to set up your project.
 
-The smart contract template also includes some examples tests under the ``tests`` directory,
-which you can delete for now. You will come back to tests later in this tutorial.
-
 In the ``lib.rs`` file, the first line brings everything from the |concordium-std|_ library into scope:
 
 .. code-block:: rust
@@ -54,7 +51,7 @@ A few basic functions are necessary for these operations to work:
 - ``vote``
 - ``get_votes``
 
-Now, let's examine the code in `the example voting smart contract here <https://github.com/Concordium/concordium-rust-smart-contracts/blob/main/examples/voting/src/lib.rs>`_.
+Now, let's examine the code in `the example voting smart contract here <https://github.com/Concordium/concordium-rust-smart-contracts/blob/main/examples/voting/src/lib.rs>`_. `Tests <https://github.com/Concordium/concordium-rust-smart-contracts/blob/main/examples/voting/tests/tests.rs>`_ are also written along with the contract, but will not be further explained in this tutorial.
 
 The ``ElectionConfig`` data structure defines the configuration of the smart contract and is an input to the ``init`` function. In the example code, it contains a description of the election, the voting options, and the deadline of the election. Voting options is provided as a list of strings, however, it is important to remember that there is a limit to the parameter size (65535 bytes), so the maximum size of the list of voting options is large, but limited. For more information, see :ref:`Contract instance limits<contract-instance-operations>`.
 

--- a/source/mainnet/tutorials/voting/voting-sc.rst
+++ b/source/mainnet/tutorials/voting/voting-sc.rst
@@ -32,7 +32,7 @@ to set up your project.
 The smart contract template also includes some examples tests under the ``tests`` directory,
 which you can delete for now. You will come back to tests later in this tutorial.
 
-In the ``lib.rs`` file, start by bringing everything from the |concordium-std|_ library into scope by adding the line:
+In the ``lib.rs`` file, the first line brings everything from the |concordium-std|_ library into scope:
 
 .. code-block:: rust
 


### PR DESCRIPTION
## Purpose

Improve the voting tutorial

## Changes

- Removed wallet tutorial section, as it was already pointing to the existing, separate guide for connecting a wallet
- The `concordium-std` library is included automatically when using the `init` command, so that is now reflected in the tutorial
- Clarified that tests do exist on github, but are not explained in the tutorial

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
