### PR TITLE
Fixed logo position and width on mobile

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -199,12 +199,12 @@ html {
 }
 /* Logo positioning */
 .navbar-header-items__start {
-    position: absolute;
+    position: relative;
     left: 0;
     padding-left: 1rem;
     z-index: 1;  /* Reduced z-index */
     background: white;
-    max-width: 20%;
+    max-width: 167px; /* Match logo's natural width*/
 }
 
 /* Menu positioning */
@@ -222,7 +222,13 @@ img.logo {
 
 /* Responsive adjustments */
 @media (max-width: 768px) {
-    .navbar-header-items:not(.navbar-header-items__start) {
-        margin-left: 150px;
+    .navbar-header-items__start{
+        max-width: 120px; /* Smaller width on mobile */
+        margin-left: 3rem; /* Make space for menu button */
+    }
+    
+    img.logo{
+        width: 100%;
+        height: auto;
     }
 }


### PR DESCRIPTION
## Purpose

Fix logo overapping menu button on mobile and wrong width.
Screenshot before: 
<img width="388" alt="Screenshot 2024-11-25 at 18 44 29" src="https://github.com/user-attachments/assets/7712b0de-abf9-4171-87ac-37642cc1eaaf">

Screenshot after fix: 
<img width="382" alt="Screenshot 2024-11-25 at 18 45 34" src="https://github.com/user-attachments/assets/803f0a93-8e7f-49ad-9f96-017e6f291088">

## Changes

1. Fix the overlapping issue by changing the logo container positioning to relative
2. Make the logo more responsive on mobile by constraining its width
3. Add space for the menu button on mobile devices
## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
