### PR TITLE
Fix redirect for buttons from the concordium website

### DIFF
--- a/source/mainnet/conf.py
+++ b/source/mainnet/conf.py
@@ -535,7 +535,7 @@ redirects = {
     "./net/browser-wallet/browser-wallet-faq": "docs/browser-wallet/browser-wallet-faq.html",
     "./net/concepts/concepts-transactions": "docs/protocol/transactions.html",
     "net/guides/developer-page": "/en/mainnet/tools/developer-page.html",
-    "net/mobile-wallet-gen2/setup-mobile-wallet": "/en/mainnet/docs/guides/setup-cryptox-wallet.html"
+    "net/mobile-wallet-gen2/setup-mobile-wallet": "/en/mainnet/docs/guides/setup-cryptox-wallet.html",
     "smart-contracts/guides/setup-tools": "/en/mainnet/docs/smart-contracts/guides/setup-contract.html",
     "smart-contracts/guides/build-schema": "/en/mainnet/docs/smart-contracts/guides/build-schema.html",
     "smart-contracts/guides/contract-dev-guides": "/en/mainnet/docs/smart-contracts/guides/build-contract.html",

--- a/source/mainnet/conf.py
+++ b/source/mainnet/conf.py
@@ -534,10 +534,11 @@ redirects = {
     "./net/mobile-wallet-gen2/faq": "docs/guides/mobule-wallet-gen2/faq.html",
     "./net/browser-wallet/browser-wallet-faq": "docs/browser-wallet/browser-wallet-faq.html",
     "./net/concepts/concepts-transactions": "docs/protocol/transactions.html",
-    "./en/mainnet/net/guides/developer-page": "en/mainnet/tools/developer-page.html",
-    "./en/mainnet/smart-contracts/guides/setup-tools": "en/mainnet/docs/smart-contracts/guides/setup-contract.html",
-    "./en/mainnet/smart-contracts/guides/build-schema": "en/mainnet/docs/smart-contracts/guides/build-schema.html",
-    "./en/mainnet/smart-contracts/guides/contract-dev-guides": "en/mainnet/docs/smart-contracts/guides/build-contract.html",
-    "./en/mainnet/smart-contracts/guides/quick-start": "en/mainnet/docs/smart-contracts/guides/quickstart.html", 
+    "net/guides/developer-page": "/en/mainnet/tools/developer-page.html",
+    "net/mobile-wallet-gen2/setup-mobile-wallet": "/en/mainnet/docs/guides/setup-cryptox-wallet.html"
+    "smart-contracts/guides/setup-tools": "/en/mainnet/docs/smart-contracts/guides/setup-contract.html",
+    "smart-contracts/guides/build-schema": "/en/mainnet/docs/smart-contracts/guides/build-schema.html",
+    "smart-contracts/guides/contract-dev-guides": "/en/mainnet/docs/smart-contracts/guides/build-contract.html",
+    "smart-contracts/guides/quick-start": "/en/mainnet/docs/smart-contracts/guides/quickstart.html", 
     "smart-contracts/tutorials/index": "/en/mainnet/tutorials/index.html"
     }


### PR DESCRIPTION
## Purpose

Fix redirect for links from buttons from the concordium website;
Also fixed 2 more links;

## Changes

problem was the following:

- when you use ./ is front, it's an absolute path, everything coming after https://developer.concordium.software/
- when not, it's relative, meaning everything after https://developer.concordium.software/en/mainnet/
- this goes both for the link you're redirecting from and the link you're redirecting to
- before, there was no need to differentiate as most paths were the similar, now, with the new structure, we need to see which need a relative path and which need an absolute path

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
