### PR TITLE
Fix last redirect, typo was there before

### DIFF
--- a/source/mainnet/conf.py
+++ b/source/mainnet/conf.py
@@ -539,6 +539,6 @@ redirects = {
     "smart-contracts/guides/setup-tools": "/en/mainnet/docs/smart-contracts/guides/setup-contract.html",
     "smart-contracts/guides/build-schema": "/en/mainnet/docs/smart-contracts/guides/build-schema.html",
     "smart-contracts/guides/contract-dev-guides": "/en/mainnet/docs/smart-contracts/guides/build-contract.html",
-    "smart-contracts/guides/quick-start": "/en/mainnet/docs/smart-contracts/guides/quickstart.html", 
+    "smart-contracts/guides/quick-start": "/en/mainnet/docs/smart-contracts/guides/quick-start.html", 
     "smart-contracts/tutorials/index": "/en/mainnet/tutorials/index.html"
     }


### PR DESCRIPTION
## Purpose

Small typo was present in my last PR:
https://github.com/Concordium/concordium.github.io/pull/1163

## Changes

Fix the typo

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
