### PR TITLE
Move sc tools section from docs to tools

### DIFF
--- a/source/mainnet/docs/smart-contracts/introduction.rst
+++ b/source/mainnet/docs/smart-contracts/introduction.rst
@@ -83,9 +83,6 @@ obligation, or some way for the highest bidder to file a complaint. Smart
 contracts cannot resolve these real-world issues automatically, and the best
 solution is likely going to depend on the specifics of the auction.
 
-Next steps
-==========
-
 Additional reading
 ------------------
 
@@ -96,23 +93,7 @@ For information about the lifecycle of smart contracts, see :ref:`Lifecycle of a
 Smart contract development tools
 --------------------------------
 
-Concordium provides a number of tools to simplify the smart contract creation and deployment process.
-
-The `VSCode extension <https://marketplace.visualstudio.com/items?itemName=Concordium.concordium-smart-contracts>`__ can help you develop Concordium smart contracts. The extension sets up the editor for development, installs the ``cargo-concordium`` smart contract development tool for all supported platforms, and provides commands in the editor for the essential workflows, such as building and testing smart contracts.
-
-You can watch a video about how to use the VSCode extension.
-
-.. raw:: html
-
-    <iframe src="https://www.youtube.com/embed/9qjcsGDeveg?si=zGDkjMAdP5JjRMd8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-
-The :ref:`integration testing library<integration-test-contract>` simplifies testing of your smart contracts before deployment.
-
-The `main library for Smart contract development <https://crates.io/crates/concordium-std>`_ can be found on crates.io.
-
-To ease deployment and initialization, you can use the `Smart contract deploy and initialize tool <https://sctools.mainnet.concordium.software/>`__. It works with the |bw| to deploy and initialize smart contracts to Mainnet and Testnet.
-
-The `Typescript smart contract client generator <https://www.npmjs.com/package/@concordium/ccd-js-gen>`_ helps you generate JavaScript or TypeScript clients for the Concordium blockchain.
+Read :ref:`developer resources <developer-page>` for information regarding tools.
 
 .. toctree::
    :hidden:

--- a/source/mainnet/tools/developer-page.rst
+++ b/source/mainnet/tools/developer-page.rst
@@ -65,7 +65,7 @@ All of our repositories are on `GitHub <https://github.com/Concordium>`__.
 
     The `Typescript smart contract client generator <https://www.npmjs.com/package/@concordium/ccd-js-gen>`_ helps you generate JavaScript or TypeScript clients for the Concordium blockchain.
 
-    See :ref:`Smart contracts <introduction>` for general information about smart contracts. 
+    See :ref:`Smart contracts <introduction>` for general information about smart contracts.
 
 .. dropdown:: Proofs
 

--- a/source/mainnet/tools/developer-page.rst
+++ b/source/mainnet/tools/developer-page.rst
@@ -47,9 +47,25 @@ All of our repositories are on `GitHub <https://github.com/Concordium>`__.
 
 .. dropdown:: Smart contracts
 
-    See :ref:`Smart contracts <introduction>` for general information about smart contracts, including a list of the available :ref:`smart contract development tools<sc-dev-tools>` to make creation, testing, and deployment easier.
+    Concordium provides a number of tools to simplify the smart contract creation and deployment process.
 
-    `The main library for developing smart contracts can be found on crates.io <https://crates.io/crates/concordium-std>`__.
+    The `VSCode extension <https://marketplace.visualstudio.com/items?itemName=Concordium.concordium-smart-contracts>`__ can help you develop Concordium smart contracts. The extension sets up the editor for development, installs the ``cargo-concordium`` smart contract development tool for all supported platforms, and provides commands in the editor for the essential workflows, such as building and testing smart contracts.
+
+    You can watch a video about how to use the VSCode extension.
+
+    .. raw:: html
+
+        <iframe src="https://www.youtube.com/embed/9qjcsGDeveg?si=zGDkjMAdP5JjRMd8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+    The :ref:`integration testing library<integration-test-contract>` simplifies testing of your smart contracts before deployment.
+
+    The `main library for Smart contract development <https://crates.io/crates/concordium-std>`_ can be found on crates.io.
+
+    To ease deployment and initialization, you can use the `Smart contract deploy and initialize tool <https://sctools.mainnet.concordium.software/>`__. It works with the |bw| to deploy and initialize smart contracts to Mainnet and Testnet.
+
+    The `Typescript smart contract client generator <https://www.npmjs.com/package/@concordium/ccd-js-gen>`_ helps you generate JavaScript or TypeScript clients for the Concordium blockchain.
+
+    See :ref:`Smart contracts <introduction>` for general information about smart contracts. 
 
 .. dropdown:: Proofs
 


### PR DESCRIPTION
## Purpose

Review and update Docs Smart Contracts section.

## Changes

- section about smart contract tools was in `DOCS`, it should be in `TOOLS` and was moved and replaced with a reference

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
