### PR TITLE
Removed ref to legacy wallets and inserted ref to cryptox

### DIFF
--- a/source/mainnet/docs/smart-contracts/guides/quick-start.rst
+++ b/source/mainnet/docs/smart-contracts/guides/quick-start.rst
@@ -64,14 +64,12 @@ Before starting, it is a good idea to read the :ref:`Smart contracts best practi
 
 .. dropdown:: Step 3 - Set up a Concordium Wallet
 
-    You need to set up a Concordium wallet and export the keys to import them to `concordium client`. You can only import keys from |bw|, |mw-gen2|, or |mw-gen1| into `concordium-client`, so you must choose one of those wallets to set up.
+    You need to set up a Concordium wallet and export the keys to import them to `concordium client`. You can only import keys from |bw| or |cryptox| into `concordium-client`, so you must choose to set up one of those wallets.
 
     - |bw| :ref:`setup<setup-browser-wallet>`
         - :ref:`Key export<export-key>`
-    - |mw-gen2| :ref:`setup<setup-g2-mobile-wallet>`
+    - |cryptox| :ref:`setup<setup-cryptox-wallet>`
         - :ref:`Key export<export-key>`
-    - |mw-gen1| :ref:`setup<setup-mobile-wallet>`
-        - :ref:`Key export<export-import>`
     - :ref:`Import keys to concordium-client<concordium-client-import-accounts-keys>`
 
     Use the testnet faucet in your wallet to get some CCDs for testing. The testnet faucet is available once you create an account.


### PR DESCRIPTION
## Purpose

The purpose of the pull request is to remove any links or references to the legacy wallets in the documentation section Docs/Smart Contracts.

## Changes

In "Concordium smart contracts quick start guide" step 3 "Set up a Concordium Wallet": Removed links to setup-mobile-wallet - both for gen1 and gen2 and replaced with link to setup-cryptox-wallet. Also updated text in step 3 accordingly.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

