### PR TITLE
Changed repo link to new one

### DIFF
--- a/source/mainnet/docs/smart-contracts/contract-schema.rst
+++ b/source/mainnet/docs/smart-contracts/contract-schema.rst
@@ -8,7 +8,7 @@
 ..
 
 .. _`custom section`: https://webassembly.github.io/spec/core/appendix/custom.html
-.. _`implementation in Rust`: https://github.com/Concordium/concordium-contracts-common/blob/main/concordium-contracts-common/src/schema.rs
+.. _`implementation in Rust`: https://github.com/Concordium/concordium-base/blob/main/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
 
 .. _contract-schema:
 


### PR DESCRIPTION
## Purpose

There was a github link pointing to an archived repository

## Changes

- changed link to point to the new repo

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
