### PR TITLE
Sc review build

### DIFF
--- a/source/mainnet/docs/smart-contracts/best-practices/costs.rst
+++ b/source/mainnet/docs/smart-contracts/best-practices/costs.rst
@@ -6,6 +6,8 @@ Cost reduction
 
 There are several ways that you can reduce transaction costs when developing your smart contracts.
 
+.. _sc-costs-custom-allocator:
+
 Use a custom allocator
 ======================
 
@@ -45,7 +47,14 @@ For very complex contracts it may be beneficial to run benchmarks to see
 whether ``bump_alloc`` is the best option. See the Rust `allocator <https://doc.rust-lang.org/std/alloc/index.html#the-global_allocator-attribute>`_
 documentation for more context and details on using custom allocators.
 
+.. note::
+
+   One interesting thing to know is that you need to be careful to not enable ``bump_alloc``
+   when using the smart contract types in other programs (e.g. `a long-lived indexer <https://github.com/Concordium/concordium-dapp-examples/blob/main/trackAndTrace/indexer/Cargo.toml#L27>`_)
+
 There are other allocators available, for example ``dlmalloc``, that can be used instead.
+
+.. _sc-costs-use-state:
 
 Use State-* types for maps, sets, and boxes
 ===========================================

--- a/source/mainnet/docs/smart-contracts/guides/build-schema.rst
+++ b/source/mainnet/docs/smart-contracts/guides/build-schema.rst
@@ -8,7 +8,7 @@ Build a contract schema
 
 This guide will show you how to build a smart contract schema, how to export it
 to a file, and/or embed the schema into the smart contract module, all using
-``cargo-concordium``.
+|cargo-concordium|_.
 
 .. note ::
 
@@ -277,3 +277,6 @@ commands print the base64 representation of the schema to the console:
    $cargo concordium schema-base64 --module "/some/path/module.wasm.v1"
 
    $cargo concordium schema-base64 --module "/some/path/module.wasm.v1" --out -
+
+.. _cargo-concordium: https://crates.io/crates/cargo-concordium
+.. |cargo-concordium| replace:: ``cargo-concordium``

--- a/source/mainnet/docs/smart-contracts/guides/compile-module.rst
+++ b/source/mainnet/docs/smart-contracts/guides/compile-module.rst
@@ -15,7 +15,7 @@ Preparation
 ===========
 
 Make sure to have Rust and Cargo installed and the ``wasm32-unknown-unknown``
-target, together with ``cargo-concordium`` and the Rust source code for a smart
+target, together with |cargo-concordium|_ and the Rust source code for a smart
 contract module, you wish to compile.
 
 .. seealso::
@@ -117,3 +117,6 @@ For example, running the following command will output your smart contract modul
    for V1 contracts. Concordium recommends using the wasm module with the ``.v1`` extension
    (the most-up-to date smart contract version).
    The file ``my_module.wasm.v1`` will be used when :ref:`deploying <deploy-module>` a smart contract on-chain.
+
+.. _cargo-concordium: https://crates.io/crates/cargo-concordium
+.. |cargo-concordium| replace:: ``cargo-concordium``

--- a/source/mainnet/docs/smart-contracts/guides/fallback-entrypoints.rst
+++ b/source/mainnet/docs/smart-contracts/guides/fallback-entrypoints.rst
@@ -22,7 +22,7 @@ You also need to have the following installed:
 .. seealso::
 
    For instructions on how to install the developer tools, see
-   :ref:`build-contract`.
+   :ref:`setup-env`.
 
 What are fallback entrypoints
 =============================

--- a/source/mainnet/docs/smart-contracts/guides/json-params.rst
+++ b/source/mainnet/docs/smart-contracts/guides/json-params.rst
@@ -8,8 +8,7 @@ This guide explains how to interact with the CIS-2 smart contract functions by p
 
 .. seealso::
 
-   For a guide on how to send interact with a smart contract using JSON see :ref:`interact-instance-json-parameters`.
-   
+   For a guide on how to interact with a smart contract using JSON parameters see :ref:`interact-instance-json-parameters`.
 
 A smart contract implementing CIS-2 must export the following functions: ``transfer()``, ``updateOperator()``, ``balanceOf()``, ``operatorOf()``, and ``tokenMetadata()``. This topic briefly describes what the required functions do and how to interact with them using JSON parameters one by one.
 

--- a/source/mainnet/docs/smart-contracts/guides/json-params.rst
+++ b/source/mainnet/docs/smart-contracts/guides/json-params.rst
@@ -6,6 +6,11 @@ JSON parameters
 
 This guide explains how to interact with the CIS-2 smart contract functions by providing input JSON parameters. This guide uses the `cis2-multi smart contract <https://github.com/Concordium/concordium-rust-smart-contracts/tree/main/examples/cis2-multi>`__ as a starting point, and then continues with a couple of custom input types.
 
+.. seealso::
+
+   For a guide on how to send interact with a smart contract using JSON see :ref:`interact-instance-json-parameters`.
+   
+
 A smart contract implementing CIS-2 must export the following functions: ``transfer()``, ``updateOperator()``, ``balanceOf()``, ``operatorOf()``, and ``tokenMetadata()``. This topic briefly describes what the required functions do and how to interact with them using JSON parameters one by one.
 
 transfer() and TransferParams

--- a/source/mainnet/docs/smart-contracts/guides/no-std.rst
+++ b/source/mainnet/docs/smart-contracts/guides/no-std.rst
@@ -47,6 +47,7 @@ You can update your `Cargo.toml` file by using:
    In ``concordium-std`` version ``>=10.0.0``, `bump_alloc <https://docs.rs/concordium-std/10.0.0/concordium_std/#use-a-custom-allocator>`_ is a feature and needs to be explicitly enabled.
    When ``std`` feature is enabled, the allocator provided by the Rust standard library is used
    by default but when the ``wee_alloc``/``bump_alloc`` feature is enabled in addition, `bump_alloc <https://docs.rs/concordium-std/10.0.0/concordium_std/#use-a-custom-allocator>`_ ( or `wee_alloc <https://docs.rs/wee_alloc/>`_) is used instead.
+   Read :ref:`sc-costs-custom-allocator` for more information on custom allocators.
 
    You can enable the ``std`` feature and the ``wee_alloc`` feature in ``concordium-std`` version in the range of ``>=6.0.0`` and ``<10.0.0`` by using:
 

--- a/source/mainnet/docs/smart-contracts/guides/setup-contract.rst
+++ b/source/mainnet/docs/smart-contracts/guides/setup-contract.rst
@@ -119,7 +119,7 @@ The *from scratch* option guides you through the process when you want to start 
 .. note::
 
    ``Wee_alloc`` is unmaintained currently and hence an optional feature for backward compatibility.
-   There are other allocators available, for example `dlmalloc <https://docs.rs/dlmalloc/>`_.
+   There are other allocators available, read :ref:`sc-costs-custom-allocator` for a guide on how to use one.
 
 .. seealso::
 


### PR DESCRIPTION
## Purpose

Finished review of the Build section in Smart Contracts  according to the DOC-301 ticket

## Changes

- removed mention of `dalloc` and replaced with a reference to `bump_alloc`, which is the latest recommended custom allocator
- added a note in the `Use a custom allocator` article mentioning to the user to be careful in the use of `bump_alloc`, with an example
- added references to `cargo-concordium` rust crate documentation
- replaced a reference to `build-contract` with a reference to `setup-env`, which is the main tutorial for installing dev tools
- added a reference in `JSON parameters` to a related guide on how to use them

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
