### PR TITLE
Removed legacy wallets from wallet activities section

### DIFF
--- a/source/mainnet/docs/guides/address-book.rst
+++ b/source/mainnet/docs/guides/address-book.rst
@@ -29,33 +29,7 @@ The address book helps you select a recipient quickly for transactions.
     #. Enter a recipient name. Enter a recipient address or scan the QR code of the recipient account.
 
     #. Tap **Save**.
-.. dropdown:: |mw-gen2|
 
-   #. Tap |wallet-settings|.
-
-   #. Select **Address book**.
-
-      .. image:: ../images/mobile-wallet-gen2/more-options.jpg
-         :width: 25%
-
-   #. You can search in the address book or scan the QR code of another account.
-
-    To add a new recipient
-
-    #. Tap **+**.
-
-    #. Enter a recipient name. Enter a recipient address or scan the QR code of the recipient account.
-
-    #. Tap **Save**.
-
-.. dropdown:: |mw-gen1|
-
-   #. Go to the |morepage| page.
-
-   #. Select **Address book**.
-
-      .. image:: ../images/mobile-wallet/MW58.png
-         :width: 25%
 
 .. dropdown:: Desktop Wallet
 

--- a/source/mainnet/docs/guides/change-account-name.rst
+++ b/source/mainnet/docs/guides/change-account-name.rst
@@ -18,16 +18,6 @@ Change account name
     #. Enter the new name and tap **Save**.
 
 
-.. dropdown:: |mw-gen2|
-
-    #. Tap on the account you want to rename.
-
-    #. In the Account details screen, tap |acct-settings|.
-
-    #. Tap **Change account name**.
-
-    #. Change the name and click |save| to save the change.
-
 .. dropdown:: Desktop Wallet
 
     You can edit the name of the account. Click |edit| to edit the account name. Click |save| to save the change.

--- a/source/mainnet/docs/guides/change-identity-name.rst
+++ b/source/mainnet/docs/guides/change-identity-name.rst
@@ -17,15 +17,6 @@ Change identity name
 
     #. Enter the new identity name and tap **Save**.
 
-.. dropdown:: |mw-gen2|
-
-    #. Tap |wallet-settings|. Select **Your identity cards**.
-
-    #. Tap the identity you want to edit.
-
-    #. On the identity card tap |edit| next to the identity name.
-
-    #. Change the name and tap **Save**.
 
 .. dropdown:: |bw|
 

--- a/source/mainnet/docs/guides/create-account.rst
+++ b/source/mainnet/docs/guides/create-account.rst
@@ -5,10 +5,10 @@
 Create an account
 =================
 
-If you are using |mw-gen1| or Desktop Wallet, when you created your :term:`identity`, it came with an :term:`initial account`. The initial account is a special account that the :term:`identity provider` submits
+If you are using Desktop Wallet, when you created your :term:`identity`, it came with an :term:`initial account`. The initial account is a special account that the :term:`identity provider` submits
 to the chain. When you already have an identity, you can create more :term:`accounts<account>` with that identity yourself.
 
-If you are using |bw|, |mw-gen2| or |cryptox|, no initial account was created when you created your :term:`identity`. You create all :term:`accounts<account>` related to your identities.
+If you are using |bw| or |cryptox|, no initial account was created when you created your :term:`identity`. You create all :term:`accounts<account>` related to your identities.
 
 To learn more about identities and accounts, see :ref:`Identities <reference-id-accounts>` and :ref:`Accounts <managing_accounts>`.
 
@@ -41,7 +41,7 @@ To learn more about identities and accounts, see :ref:`Identities <reference-id-
 .. dropdown:: Desktop Wallet
 
     .. note::
-        You can't import accounts that were created on the |mw-gen1|, |mw-gen2|, or |bw|.
+        You can't import accounts that were created on |bw|.
 
     Before you create more accounts, you need a LEDGER device with the Concordium LEDGER App installed. See :ref:`Set up the LEDGER device and install the Concordium LEDGER App<install-ledger>`.
 
@@ -98,29 +98,7 @@ To learn more about identities and accounts, see :ref:`Identities <reference-id-
         .. image:: ../images/desktop-wallet/dw-favorite-account.png
            :alt: dark account balance area with favorite button highlighted
 
-.. dropdown:: |mw-gen2|
 
-    #. Go to the **Accounts** page.
-
-    #. Tap the **+** in the upper right corner.
-
-    #. Tap the identity you want to use to create the account.
-
-        .. image:: ../images/mobile-wallet-gen2/create-acct-select-id.png
-            :width: 25%
-
-    #. Finally, tap **Submit account**.
-
-        .. image:: ../images/mobile-wallet-gen2/create-acct-submit.png
-            :width: 25%
-
-    Your new account is now visible on the Accounts page. It might take a little while for it to finalize on the chain.
-
-    You can edit the account name after it has been created so that it is more descriptive in your wallet. For more information, see :ref:`Change account name<change-mw-acct-name>`.
-
-.. dropdown:: |mw-gen1|
-
-    It is no longer possible for users of |mw-gen1| to create new accounts.
 
 .. dropdown:: |bw|
 

--- a/source/mainnet/docs/guides/create-identity.rst
+++ b/source/mainnet/docs/guides/create-identity.rst
@@ -5,16 +5,14 @@
 Create an identity
 ==================
 
-Before you can start using a Wallet and submit transactions to the blockchain, you need an identity issued by an identity provider, and, in the case of |mw-gen1| and Desktop Wallet, an initial account issued by the identity provider. The identity provider submits the initial account to the chain and knows the identity of the owner of the initial account, but not of any other accounts that you create. For |bw|, |mw-gen2|, and |cryptox| an initial account is not submitted by the identity provider.
+Before you can start using a Wallet and submit transactions to the blockchain, you need an identity issued by an identity provider, and, in the case of Desktop Wallet, an initial account issued by the identity provider. The identity provider submits the initial account to the chain and knows the identity of the owner of the initial account, but not of any other accounts that you create. For |bw| and |cryptox| an initial account is not submitted by the identity provider.
 
 To learn more about identities and accounts, see :ref:`Identities <reference-id-accounts>` and :ref:`Accounts <managing_accounts>`.
 
-.. warning::
-   You can only exchange identities and accounts between the |bw|, the |mw-gen2|, and |cryptox|.
 
 .. Note::
 
-   If using |bw|, |mw-gen2|, or |cryptox| with Digitial Trust Solutions (DTS) as your identity provider, and you have a mitID (Denmark) or Suomi.fi e-identification (Finland), you can use that to complete the identity verification process.
+   If using |bw| or |cryptox| with Digitial Trust Solutions (DTS) as your identity provider, and you have a mitID (Denmark) or Suomi.fi e-identification (Finland), you can use that to complete the identity verification process.
 
 .. dropdown:: |cryptox|
 
@@ -83,34 +81,6 @@ To learn more about identities and accounts, see :ref:`Identities <reference-id-
    .. Note::
       You can change the name of an identity after it has been created. Go to the **Identities** page. Select the identity. Click |edit| next to the identity name. Change the name and click the |save| to save the change.
 
-.. dropdown:: |mw-gen2|
-
-   You can submit requests for additional :term:`identities<identity>` in the |mw-gen2|. You do this from the **Identities** page.
-
-   #. Tap |wallet-settings|.
-
-   #. Tap **Your identity cards** page.
-
-   #. Tap the **+** in the upper right corner.
-
-   #. Select a third-party identity provider from the list. An external web page opens within the app.
-
-      .. image:: ../images/mobile-wallet-gen2/choose-idp.png
-         :width: 25%
-
-   #. Enter the information requested by the third-party identity provider. The information might vary depending on the identity provider. However, they will ask you to provide photos of identification documents and a selfie.
-
-   #. When you have submitted the information to the identity provider, you will have a pending identity in your app. The verification or rejection is usually retrieved from the identity provider within minutes, but check your app frequently to retrieve the result. It might take up to seven days for the result to appear.
-
-      .. image:: ../images/mobile-wallet/MW12.png
-         :width: 25%
-
-   You can edit the identity name after it has been created so that it is more descriptive in your wallet. This does not change anything with the identity provider or on chain. For more information, see :ref:`Change identity name<change-mw-id-name>`.
-
-
-.. dropdown:: |mw-gen1|
-
-   It is no longer possible for users of |mw-gen1| to create new identities.
 
 .. dropdown:: |bw|
 

--- a/source/mainnet/docs/guides/export-import.rst
+++ b/source/mainnet/docs/guides/export-import.rst
@@ -8,20 +8,20 @@ Make a backup of identities, accounts, and addresses
 .. Note::
 
 
-    |mw-gen2| and |bw| use a seed phrase to recover the wallet. Therefore, backup and import features are not available.
+    |bw| uses a seed phrase to recover the wallet. Therefore, backup and import features are not available.
 
     |cryptox| supports both file-based backups and seed phrase recovery.
 
     For more information, see :ref:`Recover your wallet<recover-wallet>`.
 
-To make sure that you have a backup of your accounts, identities, and addresses, Concordium strongly recommends that if you are using |mw-gen1| or Desktop Wallet, you export the data to a file you can store in a safe location. The backup will ensure that you can recover your accounts, identities, and addresses if your Wallet database becomes damaged or if, for some reason, you can't access the Wallet.
+To make sure that you have a backup of your accounts, identities, and addresses, Concordium strongly recommends that if you are using Desktop Wallet, you export the data to a file you can store in a safe location. The backup will ensure that you can recover your accounts, identities, and addresses if your Wallet database becomes damaged or if, for some reason, you can't access the Wallet.
 
 .. Warning::
    You are solely responsible for keeping your assets secure. You must never share your private keys, PIN codes, passwords, recovery phrases, LEDGER devices, or mobile devices with anyone.
 
 A backup is only necessary when creating new accounts, not every time a transaction is executed. Think of your account like a safe: it contains assets. If you lose the key, you cannot get into the safe unless you have a copy of the key. Your backup is your copy of the safe key.
 
-You can make a backup from |mw-gen1| or from Desktop Wallet but there are differences between them.
+You can make a backup from Desktop Wallet.
 
 How to proceed
 ==============
@@ -29,22 +29,17 @@ How to proceed
 Upgrade
 -------
 
-Concordium is continuously improving the security and reliability of its products, so it is vital to ensure that your |mw-gen1| or Desktop Wallet is upgraded to the latest version available. To check which version of your Concordium Wallet is currently available, refer to the :ref:`release notes<release-notes>`.
+Concordium is continuously improving the security and reliability of its products, so it is vital to ensure that your wallet is upgraded to the latest version available. To check which version of your Concordium Wallet is currently available, refer to the :ref:`release notes<release-notes>`.
 
 Final Notes
 ===========
 
-If the wallet does not have the keys for some accounts and you have previously made a wallet backup using the export functionality, uninstall and reinstall |mw-gen1|, Desktop Wallet or |cryptox|. You can then import your wallet backup into the new wallet.
+If the wallet does not have the keys for some accounts and you have previously made a wallet backup using the export functionality, uninstall and reinstall Desktop Wallet or |cryptox|. You can then import your wallet backup into the new wallet.
 
 If the wallet does not have the keys from some accounts and you do not have a backup of the keys on an exported file, these accounts cannot be used. Therefore, you should ensure that you never ask anyone to transfer CCD to such accounts. Instead, go through a new identification process and generate new accounts that can be used in the future. And remember to export a new backup of the account keys each time you have generated a new account in the app.
 
 Keep previous backup files until you have verified that your latest backup is working properly.
 
-.. Warning::
-    You can't import a backup file created in |mw-gen1| into Desktop Wallet or the other way around because the two wallets handle private keys in different ways. If you try, the import will fail.
-
-    You also can't import a backup file from |mw-gen1| to |mw-gen2|, but you *can* import it to |cryptox|.
-    For more information, see :ref:`Deciding between the Wallets <choosing-wallet>`.
 
 How to back up and import
 =========================
@@ -128,93 +123,13 @@ How to back up and import
 
 .. _mobile-wallet-recover:
 
-.. dropdown:: |mw-gen1|
 
-    .. Warning::
-        **Backup is essential. If you lose your mobile phone or need to restore your mobile phone and you don't have a backup from the Mobile Wallet, you can't access your wallet and your CCDs are permanently inaccessible.**
-        **Concordium does not take any responsibility if you lose access to your accounts. Concordium strongly advise you to complete a backup every time you create an account and store the backup file in a secure place - preferably offline.**
+.. dropdown:: |bw|
 
-    Because the |mw-gen1| does not use a seed phrase, your backup file is the only way you can restore your account keys should you lose your phone or have to re-install your phone or wallet. You will permanently lose access to your wallet if you do not have a backup of your private key file. Concordium cannot recover your private keys if you lose them. If you don’t make a backup file you will lose access to your tokens forever.
+    You cannot back up |bw| to a file. It uses a seed phrase to :ref:`recover your accounts, identities, and private keys<recover-wallet>`.
 
-    If you set up a new phone and transfer the wallet, you will lose the private keys; they can only be recovered from the pre-exported backup file.
+    You also can't import a back-up file into the |bw|.
 
-    Account keys are not stored in the cloud, only on the device itself in order to protect your security.
-
-    A new backup file should be exported EVERY time a new account is made, otherwise keys for the account can´t be recovered.
-
-    The |mw-gen1| provides built-in functionality to export wallet backups, encrypted under a passcode you choose. The wallet backup contains the keys for all wallet accounts. Each account has its own keys. Every time you make a new account in your wallet, you have to make a wallet backup to include the newly created account keys.
-
-    .. Warning:
-        Concordium strongly urges you to backup your account keys using the export function in the wallet whenever a new account has been created. The wallet backup as well as the export password must be stored securely. You cannot recover your accounts without a wallet backup and its passcode.
-
-    Even if you have access to the wallet and can see the accounts after a phone restoration operation or similar action, the keys to the accounts on the wallet may be missing, in which case you don’t have access to the CCDs. The following describes how you can check if you have the necessary keys and access to your accounts.
-
-    .. dropdown:: Export
-
-        .. Warning::
-            The only way to ensure that your backup includes the keys for all of your accounts is to follow the instructions below. Any backup made in any other way (e.g., backup of mobile phone) will **NOT** include your account keys and may result in you losing access to your accounts.
-
-        #. Tap **Backup** in the lower left corner.
-
-        #. Enter your biometrics or app passcode.
-
-        #. Read the information about the export and tap **Continue**.
-
-        #. Choose a password with a minimum of 6 characters to encrypt your export. Make sure to choose a secure password and keep it safe. Anyone with the password will be able to unlock the export and make transfers from your account. Tap **Continue**.
-
-        #. Choose an option for sending or saving the export file, such as Mail.
-
-        Concordium strongly recommends that you store the backup file in a safe location and not on the phone itself. It's also vital that you keep the password to the backup file safe. Anyone with access to the file can gain access to your crypto assets. Concordium is not able to recover backup passwords.
-
-    .. dropdown:: How to check that you have your account keys
-
-        The app does not indicate if it has the keys to the accounts. To check whether the app has the keys for all accounts, do the following:
-
-        #. Open your wallet.
-        #. Create one new account for each of your identities.
-
-        If this succeeds for all identities, the wallet has all the necessary account keys. The wallet does not have the keys to the accounts created under identities where this fails.
-
-    .. dropdown:: Import
-
-        Depending on whether you are using an Android phone or an iPhone, the import process differs slightly.
-
-        .. dropdown:: Android
-
-            #. Go to the |morepage| page.
-
-            #. Tap **Restore Backup**.
-
-            #. Use the Android system prompt to browse to your export and select the file.
-
-            #. Enter the password you chose upon making the export.
-
-            #. Enter your biometrics or app passcode.
-
-            #. Review your import and tap **Ok, thanks**.
-
-        .. dropdown:: iOS
-
-            #. Find the file you want to import on your iPhone.
-
-            #. Choose the iOS “Share” option. Choose Concordium Mobile Wallet as the app to open the file.
-
-            #. Enter the password you chose upon making the export.
-
-            #. Enter your biometrics or app passcode.
-
-            #. Review your import and tap **Ok, thanks**.
-
-.. dropdown:: |mw-gen2| and |bw|
-
-    You cannot back up |mw-gen2| or |bw| to a file. They use a seed phrase to :ref:`recover your accounts, identities, and private keys<recover-wallet>`.
-
-    You also can't import a back-up file into either of these wallet apps.
-
-
-            .. note::
-
-               The option to view the seed phrase is available in |mw-gen2| for Android version 1.3.0 or greater in the Wallet Settings |wallet-settings|. However you cannot simply upgrade to version 1.3.0 and use this feature. Instead, you must either create a new wallet or recover your wallet to be able to see this option in Wallet Settings.
 
     If you need to export your private key to use in Concordium Client (for example, to work with smart contracts or to set up a validator node), see :ref:`Export a private key<export-key>`.
 

--- a/source/mainnet/docs/guides/recover-wallet.rst
+++ b/source/mainnet/docs/guides/recover-wallet.rst
@@ -156,42 +156,6 @@ You may need to recover your wallet, e.g. if you've switched devices or lost acc
 
         If you forget your passcode for your installed |bw|, you will need to :ref:`remove the extension in your internet browswer and reinstall it<setup-browser-wallet>`, choosing the option to recover your wallet. Use your seed phrase to recover the wallet.
 
-.. dropdown:: |mw-gen2|
-
-    #. After reinstalling the |mw-gen2| app, open the app.
-
-    #. On the Getting Started screen, tap **Recover wallet**.
-
-        .. image:: ../images/mobile-wallet-gen2/choice-start.png
-            :width: 25%
-
-    #. After the screens explaining recovery tap **Continue**.
-
-    #. Enter each word of your recovery phrase in the correct order. When you start typing, possible words appear for you to select. Once the words are correct, tap **Continue** to submit the recovery request to the identity provider(s).
-
-        .. image:: ../images/mobile-wallet-gen2/recovery-enter-phrase.png
-            :width: 25%
-
-    #. When recovery is successful, the screen below appears.
-
-        .. image:: ../images/mobile-wallet-gen2/recovery-success.png
-            :width: 25%
-
-    Sometimes recovery can take longer. You might encounter a partial recovery.
-
-    This means that accounts and identities have been partially recovered. This could be because one of the identity providers is unresponsive. Tap **Try again** to attempt recovery again now or tap **Continue** to wait until later to try to recover. If you wait until later you can continue to the wallet.
-
-    To continue recovery, tap |wallet-settings| and tap **Recovery** to continue.
-
-    .. Note::
-
-        When you recover your wallet, any account names that you might have edited will be reset to the account number. You can :ref:`edit the account name<change-mw-acct-name>`, if desired.
-
-.. dropdown:: |mw-gen1|
-
-    Recovery of |mw-gen1| requires a valid backup file. For more information about this process, see :ref:`backup and restore<mobile-wallet-recover>`.
-
-    If you want to recover your |mw-gen1| wallet to |cryptox|, see the description above for recovering on |cryptox| with a backup file.
 
 .. dropdown:: Desktop Wallet
 

--- a/source/mainnet/docs/guides/recovery.rst
+++ b/source/mainnet/docs/guides/recovery.rst
@@ -8,34 +8,24 @@ Backup and recovery
 It can be necessary to recover your wallet, for example if you get a new computer or mobile device. It is important to know how you can recover your wallet on a device if necessary. There are differences between what the wallets require for recovery.
 
 .. list-table::
-   :widths: 10 10 10 10 10
+   :widths: 10 10 10
    :header-rows: 1
 
    *  - Desktop Wallet
-      - |mw-gen1|
-      - |mw-gen2|
       - |bw|
       - |cryptox|
    *  - Backup recommended; can recover without backup
-      - Backup required
-      - Seed phrase required
       - Seed phrase required
       - Seed phrase required
    *  - Backup file includes account names and addresses, identities, and the address book. LEDGER device is needed for a full recovery.
-      - Backup file includes accounts, identities, address book, and private keys.
-      - Backup is not necessary but seed phrase is needed.
       - Backup is not necessary but seed phrase is needed.
       - Backup is not necessary but seed phrase is needed.
    *  - Private keys are stored on the LEDGER device that is secured by a PIN code and backed up by recovery phrase.
-      - Private keys are stored in the wallet.
-      - Private keys are stored in the wallet and backed up by a seed phrase.
       - Private keys are stored in the wallet and secured by the passcode used to encrypt the wallet and backed up with the seed phrase.
       - Private keys are stored in the wallet and backed up by a seed phrase.
    *  - Cannot recover in other wallet types
-      - Cannot recover in other wallet types
-      - Can recover in |mw-gen2| and |bw|
-      - Can recover in |bw| and |mw-gen2|
-      - Can recover in |bw| and |mw-gen2|; |mw-gen1|, |mw-gen2|, and |bw| can be recovered in |cryptox|
+      - Can recover in |bw| and |cryptox|
+      - Can recover in |bw| and |cryptox|
 
 .. toctree::
    :hidden:

--- a/source/mainnet/docs/mobile-wallet/change-passcode-mw.rst
+++ b/source/mainnet/docs/mobile-wallet/change-passcode-mw.rst
@@ -28,49 +28,6 @@ If you want to change your passcode or enable/disable your biometrics (on a mobi
 
    #. Choose whether or not to enable biometrics.
 
-.. dropdown:: |mw-gen2|
-
-   #. Tap |wallet-settings|.
-
-   #. Select **Update Passcode & Biometrics**.
-
-      .. image:: ../images/mobile-wallet-gen2/more-options.jpg
-         :width: 50%
-         :alt: screen with settings menu
-
-   #. Tap **Continue**.
-
-   #. Enter your old passcode or biometrics.
-
-   #. Enter a new six-digit passcode, or choose **Use full password instead** if you’d rather use a full password.
-
-   #. Choose whether or not to enable biometrics.
-
-.. dropdown:: |bw|
-
-   #. Click |hamburger-bw| and select **Wallet Settings**.
-
-   #. Click **Change passcode**.
-
-   #. Enter and confirm your new passcode.
-
-.. dropdown:: |mw-gen1|
-
-   #. Go to the |morepage| page.
-
-   #. Select **Update Passcode & Biometrics**.
-
-      .. image:: ../images/mobile-wallet/MW58.png
-         :width: 50%
-         :alt: screen with settings menu
-
-   #. Tap **Continue**.
-
-   #. Enter your old passcode or biometrics.
-
-   #. Enter a new six-digit passcode, or choose **Use full password instead** if you’d rather use a full password.
-
-   #. Choose whether or not to enable biometrics.
 
 .. dropdown::  Desktop Wallet
 


### PR DESCRIPTION
## Purpose

The purpose of the pull request is to remove any description of or reference to the legacy wallets in pages under the Wallet activities section.

## Changes

The following pages were updated:

- Create an identity
- Change identity name
- Create an account
- Change account name
- Make a backup
- Recover wallet
- Update passcode and biometrics
- Manage address book

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf
