### PR TITLE
Removed legacy wallets from the Downloads page

### DIFF
--- a/source/mainnet/docs/installation/downloads.rst
+++ b/source/mainnet/docs/installation/downloads.rst
@@ -47,42 +47,7 @@ It is the main Concordium mobile wallet and has the widest set of features.
 
    You can download standalone installable packages (APKs) for Android here: https://github.com/Concordium/cryptox-android/releases
 
-.. _downloads-mwgen2:
 
-|mw-gen2|
-========================
-
-The |mw-gen2| is available for iOS and Android™. The |mw-gen2| supports iOS 15 or later and Android 8 or later.
-
-.. Note::
-
-   The |mw-gen2| is not supported on tablet devices.
-
-.. dropdown:: Mainnet
-
-   You can find |mw-gen2| on App Store and on Google Play.
-
-      .. image:: ../images/mobile-wallet/app-store-badge.svg
-         :width: 23%
-         :target: https://apps.apple.com/us/app/concordium-blockchain-wallet/id6444703764
-      .. image:: ../images/mobile-wallet/google-play-badge.png
-         :width: 29.5%
-         :target: https://play.google.com/store/apps/details?id=software.concordium.mobilewallet.seedphrase.mainnet
-
-.. dropdown:: Testnet
-
-   **iOS**
-
-   #.  Install `TestFlight <https://apps.apple.com/us/app/testflight/id899247664>`__ on your iPhone to get the |mw-gen2| for Testnet on iOS.
-   #.  Follow `this link <https://testflight.apple.com/join/YaKKqYMA>`__ on your iPhone to join our beta. You must have TestFlight installed.
-
-   **Android**
-
-   Click below to download the Android version of Concordium Wallet for Mobile for Testnet.
-
-      .. image:: ../images/mobile-wallet/google-play-badge.png
-         :width: 29.5%
-         :target: https://play.google.com/store/apps/details?id=software.concordium.mobilewallet.seedphrase.testnet
 
 .. _downloads-browser-wallet:
 .. _downloads-browser-wallet-testnet:
@@ -151,42 +116,6 @@ Concordium LEDGER App
 
 Install the LEDGER App for use with the Desktop Wallet from LEDGER Live. For information, see :ref:`Install the LEDGER app<install-ledger>`.
 
-.. _downloads-mwgen1:
-
-|mw-gen1|
-========================
-
-.. warning:: |mw-gen1| no longer supports creating new accounts and identities. It can only be used to recover a wallet for a user who already has this wallet type and a backup file.
-
-The |mw-gen1| is available for iOS and Android™. The |mw-gen1| supports iOS 13 or later and Android 8 or later.
-
-.. Note::
-
-   The |mw-gen1| is not supported on tablet devices.
-
-.. dropdown:: Mainnet
-
-   You can find |mw-gen1| on App Store and on Google Play.
-
-      .. image:: ../images/mobile-wallet/app-store-badge.svg
-         :width: 23%
-         :target: https://apps.apple.com/us/app/concordium-mobile-wallet/id1566996491
-      .. image:: ../images/mobile-wallet/google-play-badge.png
-         :width: 29.5%
-         :target: https://play.google.com/store/apps/details?id=software.concordium.mobilewallet.mainnet
-
-.. _downloads-mobile-wallet-testnet:
-
-.. dropdown:: Testnet
-
-   **iOS**
-
-   #.  Install `TestFlight <https://apps.apple.com/us/app/testflight/id899247664>`__ on your iPhone to get the Concordium Mobile Wallet for Testnet on iOS.
-   #.  Follow `this link <https://testflight.apple.com/join/HZRi1WDT>`__ on your iPhone to join our beta. You must have TestFlight installed.
-
-   **Android**
-
-   - `Download the Android version of Concordium Mobile Wallet for Testnet <https://distribution.testnet.concordium.com/tools/android/concordium-mobile-wallet_3.2.1(115).apk>`_
 
 .. _concordium-node-and-client-download:
 


### PR DESCRIPTION
## Purpose

The purpose of the pull request is to delete the legacy wallets from the Downloads page.

## Changes

Deleted legacy wallet sections on Downloads page.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.


By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf
