### PR TITLE
Restore CryptoX End User License Terms

### DIFF
--- a/source/mainnet/docs/guides/cryptox-terms.rst
+++ b/source/mainnet/docs/guides/cryptox-terms.rst
@@ -1,0 +1,206 @@
+.. include:: ../../variables.rst
+.. _cryptox-terms:
+
+==================
+End User License Terms for |cryptox|
+==================
+
+Effective April 1, 2023
+
+These End User License Terms (these **“Terms”**) constitute a legally binding agreement made between you, whether personally or on behalf of an entity (**“you”**) and Concordium Software ApS (together with its subsidiaries and affiliates, **“we”**, **“us”**, or **“our”**) governing your download, installation, and use of the CryptoX Wallet in the form of browser extensions, mobile applications, desktop applications, or other applications or API (collectively, the **“App”**). The App enables users to self-custody digital assets and verified credentials, connect to blockchains, applications and protocols running on blockchains such as, but not limited to layer-2 solutions, decentralized applications (**“dApps”**) and bridges. The App also includes links to support channels and other information resources available by the use of third-party tools (such third-party tools, applications, and protocols, together **“Third Party Services”**).
+You agree that by downloading, installing, and using the App, you expressly acknowledge that you have read and agree to be bound by these Terms and any important notices posted from time to time on [●], which is hereby incorporated herein by reference. IF YOU DO NOT AGREE WITH THESE TERMS, THEN YOU ARE EXPRESSLY PROHIBITED FROM USING THE APP AND THE THIRD-PARTY SERVICES AND YOU MUST DISCONTINUE USE IMMEDIATELY.
+
+Summary
+=======
+
+Important notice (provided for convenience only; please review the relevant provisions in these Terms):
+
+1. Your responsibility: The App is self-custodial in nature. You are solely responsible for the safeguarding, retention and security of your seed phrase, private keys, and password. If you lose your seed phrase, private keys, or password, you will not be able to access your digital assets and your digital assets may be lost. You acknowledge that we cannot recover any seed phrase, private key or password and cannot stop, otherwise interfere, or reverse any transfer of digital assets by you.
+
+2. Third Party Services: If you choose to connect Third Party Services, you will be interacting directly with such services and will be subject to their terms, policies, and fees. We are not liable for any loss or damages you may incur arising from or in connection with Third Party Services.
+
+3. Liability: You agree that our liability, and that of any, is limited to the maximum extent permissible by applicable law.
+
+4. Indemnity: You will indemnify us for any third-party claim in connection with your use of the App and other scenarios.
+
+5. Release: If you have a dispute with a third-party in relation to the App, you release us from any and all claims, demands, and damages (actual and consequential) of every kind and nature, known and unknown, arising out of or in any way connected with such dispute.
+
+We reserve the right, in our sole discretion, to make changes or modifications to these Terms at any time and for any reason. We will alert you about any changes by updating the date above and make the changes visible via the App. It is your responsibility to periodically review these Terms to stay informed of updates. You will be subject to, and will be deemed to have been made aware of, and to have accepted, the changes in any revised Terms by your continued use of the App after the date such revised Terms are posted.
+
+The App is not intended for download to or use by any person or entity in any jurisdiction or country where such download or use would be contrary to law or regulation or which would subject us to any registration requirement within such jurisdiction or country. Accordingly, persons, who choose to download and use the App from such other locations, do so on their own initiative and are solely responsible for compliance with local laws, if and to the extent local laws are applicable.
+
+The App is intended for users who have the legal capacity and are at least the legal age required under applicable laws to enter into a binding contract such as these Terms. Persons under this age are not permitted to download, install, and use the App.
+
+If you breach any of the Terms, your authorization to use the App will automatically terminate. We reserve the right to pursue any additional remedies available in law or equity.
+
+Please refer to section 15 of these Terms of Use for information about how we collect, use, share and otherwise process information about you.
+
+1. Intellectual property; License to use the app
+================================================
+
+1.1. Unless otherwise indicated, the App is our proprietary property and all source code, databases, functionality, software, website designs, information, audio, video, text, photographs, files in whatever format (whether already existing or newly generated while using the App) and .graphics (excluding Third Party Content as defined below) on the App (collectively, the **“Content”**) and the trademarks, service marks, and logos contained therein (the “Marks”) are owned or controlled by us or licensed to us, and are protected by copyright, trademark and other intellectual property laws and international conventions. You are not permitted to use the Marks without the prior written consent of the owner of the Mark.
+
+1.2. Except as expressly provided herein and of any software code of the App that is made available under an open-source license (if any), we and our licensors do not grant any express or implied license to the App or the Content. You agree not to copy, reproduce, aggregate, republish, download, post, display, transmit, modify, rent, lease, loan, sell, assign, distribute, license, sublicense, sell, reverse engineer, create derivative works based on, or otherwise exploit for any commercial purposes whatsoever, the App, or the Content without our express prior written permission.
+
+1.3. If you are eligible to use the App, you are granted a limited, non-exclusive, non-sublicensable and non-transferable license to download, install, and use the App and to download a copy of any portion of the Content to which you have properly gained access solely for the purposes permitted hereunder. You may not modify or alter the Content in any way. We reserve all rights not expressly granted to you in and to the App, the Content, and the Marks.
+
+2. Third party services and the blockchains
+===========================================
+
+2.1. You may connect the App with Third Party Services. Third Party Services may enable you to interact directly with dApps in particular to purchase and sell digital assets or otherwise execute or use digital assets for whatever reason, and any sites, which provides market data for various digital assets. If you connect or use Third Party Services, please note that you are interacting, directly or indirectly, with such services and dApps and will be subject to their terms, policies, and fees. Please review the terms, policies, and fees of such third parties, which will be in addition to these Terms. You agree that the providers of such Third-Party Services may disclaim any liability to you.
+
+2.2. When you use the App to interact with blockchain you acknowledge that most blockchains are open-source Internet-based distributed ledger protocols (web3) composed of many different and evolving components contributed by a wide variety of participants. You acknowledge that all access to and use of blockchains is at the sole risk of the person accessing or using such blockchains. Blockchains are generally decentralized and permissionless. They have no single source of truth, no responsible centralized operator, no single point of failure, and no person or authority that alone has the ability or authority to intervene in or make changes to the data, the deployed versions, or the smart contracts that are part of or built upon blockchains.
+
+2.3. We do not have any control over Third Party Services or blockchains. We make no warranties or representations, express or implied, about Third Party Services or any blockchain you interact, the third parties that developed, deployed, or contributed to Third Party Services or any blockchain or the third parties that operate Third Party Services or any blockchain, if any, the information contained on them or the suitability of their products or services. In addition, we offer no guarantees and assume no responsibility or liability of any type arising from or in connection with Third Party Services or any blockchain, including, without limitation, any loss or theft of funds or any liability resulting from the availability (or lack thereof) of Third-Party Services or any blockchain, or any content located on or through Third Party Services or any blockchain, and any incompatibility between Third Party Services, any blockchain and the App. You agree that you will not hold us responsible or liable with respect to the Third-Party Services or any blockchain that you interact or seek to do so.
+
+3. User warranties and covenants
+================================
+
+By using the App, you warrant and covenant that:
+
+1. You have the legal capacity to enter into, and you agree to comply with, these Terms;
+
+2. If you are entering into these Terms for an entity, such as the legal entity, you represent to us that you have legal authority to bind that entity;
+
+3. You are at least the legal age and have the capacity required under applicable laws to enter into a binding contract such as these Terms;
+
+4. Your use of the App will not violate any applicable law or regulation, including but not limited to anti-money laundering, sanction and other criminal or administrative laws;
+
+5. You are not located, incorporated, or otherwise established in, or a citizen or resident of a jurisdiction where it would be illegal under applicable law for you (by reason of your nationality, domicile, citizenship, residence or otherwise) to access or use the App.
+
+4. Acceptable use policy
+========================
+
+You may not download, install, and use the App for any purpose other than that for which we make the App available. As a user of the App, you agree not to:
+
+1. Systematically retrieve data or other content from the App to create or compile, directly or indirectly, a collection, compilation, database, or directory without written permission from us.
+
+2. Circumvent, disable, or otherwise interfere with security-related features of the App, including features that prevent or restrict the use or copying of any Content or enforce limitations on the use of the App and/or the Content contained therein.
+
+3. Make improper use of our support services or submit false reports of bugs, loss, abuse, or misconduct.
+
+4. Use the App to violate any applicable laws or regulations.
+
+5. Engage in unauthorized framing of or linking to the App.
+
+6. Delete the copyright or other proprietary rights notice from any Content.
+
+7. Harass, annoy, intimidate, or threaten any of our employees or agents engaged in providing any portion of the App to you.
+
+8. Attempt to bypass any measures of the App designed to prevent or restrict the use of the App, or any portion of the App.
+
+9. Copy or adapt the App’s software, except as expressly provided herein and of any software code of the App that is made available under an open-source license (if any).
+
+10. Decipher, decompile, disassemble, or reverse engineer any of the software and data comprising or in any way making up a part of the App.
+
+11. Violate, misappropriate, or infringe the rights of us our users or third parties, including privacy, publicity, intellectual property, or other proprietary rights.
+
+Any use of the App in violation of the foregoing violates these Terms and may result in, among other things, termination, or suspension of your rights to use the App.
+
+5. Submissions
+==============
+
+You acknowledge and agree that any questions, comments, suggestions, ideas, feedback, or other information regarding the App (**“Submissions”**) provided by you to us shall become our sole property. We shall own the exclusive rights, including all intellectual property rights, and shall be entitled to the unrestricted use and dissemination of these Submissions for any lawful purpose, commercial or otherwise, without acknowledgment or compensation to you. You hereby waive all moral rights to any such Submissions, and you hereby warrant that any such Submissions are originally from you or that you have the right to submit such Submissions. You agree there shall be no recourse against us for any alleged or actual infringement or misappropriation of any proprietary right in your Submissions.
+
+6. App management
+=================
+
+We reserve the right, but not the obligation, to: (1) monitor the App for violations of Terms; (2) take appropriate legal action against anyone who, in our sole discretion, violates the law or these Terms, including without limitation, reporting such user to law enforcement authorities; (3) in our sole discretion and without limitation, refuse, restrict access to, or limit the availability of the App, to the extent feasible; and (4) otherwise manage the App in a manner designed to protect our rights and property and to facilitate the proper functioning of the App.
+
+7. Term and termination
+=======================
+
+7.1. These Terms shall remain in full force and effect while you use the App. WITHOUT LIMITING ANY OTHER PROVISION OF THESE TERMS, WE RESERVE THE RIGHT, IN OUR SOLE DISCRETION AND WITHOUT NOTICE OR LIABILITY, TO DENY USE OF THE APP, TO ANY PERSON FOR ANY REASON OR FOR NO REASON, INCLUDING WITHOUT LIMITATION FOR BREACH OF ANY WARRANTY, OR COVENANT CONTAINED IN THESE TERMS OR OF ANY APPLICABLE LAW OR REGULATION. WE MAY TERMINATE YOUR ACCESS OR USE OF THE APP, WITHOUT WARNING, IN OUR SOLE DISCRETION.
+
+8. Modifications and corrections
+================================
+
+8.1. We do not guarantee the completeness or accuracy of any information provided to you on or through the App. We reserve the right to change, modify, or remove the contents of the App at any time or for any reason at our sole discretion without notice. However, we have no obligation to update any information on the App.
+
+8.2. We may from time to time in our sole discretion develop and provide App updates, which may include upgrades, bug fixes, patches, other error corrections, and/or new features (collectively, including related documentation, **“Updates”**). Updates may also modify or delete in their entirety certain features and functionality. You agree that we have no obligation to provide any Updates or to continue to provide or enable any particular features or functionality. Based on your device settings, when your device is connected to the internet either:(a) the App will automatically download and install all available Updates; or (b) you may receive notice of or be prompted to download and install available Updates.
+
+8.3. You shall promptly download and install all Updates and acknowledge and agree that the App or portions thereof may not properly operate should you fail to do so. You further agree that all Updates will be deemed part of the App and be subject to all terms and conditions of these Terms. Updating the App may require you to re-enter your seed phrase, private keys, or password. If you lose your seed phrase, private keys, or password, your digital assets allocated to your address may be lost (see section 11.1).
+
+9. No warranty and limitations of liability
+===========================================
+
+9.1. **THE APP IS PROVIDED** “AS IS” AND “AS AVAILABLE,” WITHOUT WARRANTY OF ANY KIND. WITHOUT LIMITING THIS, WE EXPRESSLY DISCLAIM ALL WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, REGARDING THE APP INCLUDING WITHOUT LIMITATION ANY WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, SECURITY, ACCURACY, AND NON-INFRINGEMENT.
+
+WE DO NOT WARRANT THAT THE APP WILL MEET YOUR REQUIREMENTS; THAT THE APP WILL BE UNINTERRUPTED, TIMELY, SECURE, OR ERROR-FREE; THAT ANY DEFECTS OR ERRORS WILL BE CORRECTED; OR THAT THE APP IS FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. YOU ASSUME FULL RESPONSIBILITY AND RISK OF LOSS RESULTING FROM YOUR DOWNLOADING, INSTALLING AND/OR USE OF THE APP.
+
+9.2. TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW: IN NO EVENT WILL WE, OUR RESPECTIVE PAST, PRESENT, AND FUTURE EMPLOYEES, OFFICERS, DIRECTORS, CONTRACTORS, CONSULTANTS, SUPPLIERS, VENDORS, SERVICE PROVIDERS, SUBSIDIARIES, AFFILIATES, AGENTS, REPRESENTATIVES, PREDECESSORS, SUCCESSORS AND ASSIGNS (**“COMPANY PARTIES”**) BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE, ENHANCED OR EXEMPLARY DAMAGES OF ANY KIND (INCLUDING, BUT NOT LIMITED TO, WHERE RELATED TO LOSS OF REVENUE, INCOME OR PROFITS, LOSS OF USE OR DATA, OR DAMAGES FOR BUSINESS INTERRUPTION OR DIMINUTION IN VALUE) ARISING OUT OF OR IN ANY WAY RELATED TO YOUR DOWNLOAD, INSTALLATION, AND USE OF THE APP OR OTHERWISE RELATED TO THESE TERMS, REGARDLESS OF THE FORM OF ACTION, WHETHER BASED IN CONTRACT, TORT (INCLUDING, BUT NOT LIMITED TO, SIMPLE NEGLIGENCE, WHETHER ACTIVE, PASSIVE OR IMPUTED), OR ANY OTHER LEGAL THEORY (EVEN IF THE PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND REGARDLESS OF WHETHER SUCH DAMAGES WERE FORESEEABLE).
+
+10. Risks
+=========
+
+The App is developed using and made available on blockchain technology. As this is an emerging technology, it is subject to additional risks. By using the App, you explicitly acknowledge and accept all such risks. You should note that this is not an exhaustive list of all the risks associated with digital assets.
+
+10.1 No custody
+---------------
+
+The App is self-custodial in nature on your device. As such, you are solely responsible for the safeguarding, retention and security of your seed phrase, private keys, password, and your device. Your seed phrase is the master key that allows you to access your digital assets. If you lose your seed phrase, you may not be able to access your digital assets. Do not share your seed phrase, private keys, or password with anyone. Anyone who knows your seed phrase will be able to access and transfer your digital assets. You acknowledge that we do not store and are not responsible in any way for the safeguarding, retention, security or recovery of your seed phrase, private keys, or password. You agree to release us from any liability for and against any loss, damage, liability, claim, or demand arising from or in connection with the loss of your seed phrase, private keys, or password.
+
+10.2. No Advice / No Reliance
+-----------------------------
+
+10.2.1. All information visible on the App or in connection with your use of the App is for informational purposes only. The App is not intended as, and does not provide, any investment or financial advice. With respect to any financial or investment decisions, we recommend you conduct your own research to properly evaluate the risks and benefits of any transaction. We recommend you seek the advice and guidance of qualified accountants, financial advisors, tax advisors, legal counsel, and investment advisors, in connection with any investment or financial transaction. You agree to be held fully responsible for your decisions.
+
+10.2.2. None of the information visible on the App when the App is connected to any blockchain or decentralized application or protocol, including without limitation any bid, offer, price, quantity, volume, depth, or other data, represents an offer or a solicitation of an offer to enter into a transaction with us or an offer by us to enter into any transaction on your behalf.
+
+10.2.3 You warrant that you have sufficient knowledge, sophistication, professional advice and technical and investing experience to make your own evaluation of the merits and risks of any transaction entered into through the App or any underlying digital asset. You should not use the App or use or transact in digital assets unless you fully understand the nature of the transaction you are entering into and the extent of your exposure to loss. We are not responsible for any loss you may incur as a result of a decrease in the value of your digital assets, including without limitation, in connection with the lack of availability or degraded performance of the App.
+
+10.3. Digital Asset Volatility and Characteristics
+--------------------------------------------------
+
+10.3.1. Using, buying, holding, and selling digital assets involve certain risks of financial loss. Any digital asset may be subject to fluctuations in value, including a total loss of value. The volatility and unpredictability of the price of digital assets relative to fiat currency may result in significant loss over a short period of time. The nature of digital assets may lead to an increased risk of fraud or cyber-attack. You acknowledge these risks and agree that we cannot be held liable for such fluctuations or loss of value.
+
+10.3.2. Digital assets and their underlying blockchain networks are complex emerging technologies that are typically globally distributed across multiple, unaffiliated nodes. They may experience delays, halts or go offline as a result of errors, forks, attacks, or other unforeseeable reasons. They are also subject to speculative interest and regulatory attention, which may contribute to price volatility and liquidity constraints. The compatibility of a digital asset or with Third Party Services on the App does not indicate our approval or disapproval of the digital asset or its underlying technology and should not be treated as a substitute for your own understanding of the risks specific to each digital asset. We provide no warranty as to the suitability of any digital assets or Third-Party Services and assume no fiduciary duty to you in connection with your use of the App.
+
+10.3.3. All digital asset transactions are irreversible. You accept all consequences of using or transacting digital assets. Once you send digital assets to an address, you accept the risk that you may permanently lose access to it. You assume all liability for any losses incurred as a result of your transactions or transfers of digital assets. You are solely liable for verifying the accuracy of any external wallet address and the identity of the recipient. We do not control any blockchain network and cannot guarantee that any transfer will be confirmed or transferred successfully by the network. We are not responsible for any losses or for taking any actions to attempt to recover any lost, stolen, misdirected or irrecoverable digital assets.
+
+10.4. Technical and Operational Risks
+-------------------------------------
+
+10.4.1. The technology underlying digital assets, including without limitation applied cryptography, blockchain, networking and distributed systems, and smart contracts, is subject to change at any time. Such changes may affect the App. You assume full responsibility for monitoring such technological changes and understanding their impact on your digital assets.
+
+10.4.2. The digital assets and their underlying networks are under development and continue to evolve. As such, they may be subject to material and sudden changes that may have a significant impact on the availability, usability, or value of a particular digital asset. In addition, as a general matter, the operations, functionalities, development and distributions of digital assets and their underlying networks are beyond our control. You agree not to hold us liable for any related losses.
+
+10.4.3. Blockchain networks are susceptible to various attacks such as an attack in which an attacker gains control of a requisite mining or validating power on the network. We cannot prevent or mitigate attacks on blockchain networks and has no obligation to engage in activity in relation to such attacks.
+
+10.4.4. We cannot guarantee the App will be available at all times. The App may include coding errors or other errors.
+
+10.5 Tax and Compliance
+-----------------------
+
+10.5.1. Digital assets may be subject to taxation. It is your sole responsibility to determine whether, and to what extent, any taxes apply to any transactions you conduct using the App, and to withhold, collect, report, and remit the correct amounts of taxes to the appropriate tax authorities.
+
+10.5.2 You are responsible for complying with all applicable laws. You agree that we are not responsible for determining whether or which laws and regulations may apply to your activities or transactions.
+
+10.6. Legislative and Regulatory Risks
+--------------------------------------
+
+Digital assets and any software or service related to digital assets are subject to legal and regulatory uncertainty in many jurisdictions. As such, legislative and regulatory changes or actions may adversely affect the usage, transferability, transactability and value of digital assets, or your access to, and our ability make the App available. You acknowledge and accept the risks that such changes may bring and that we are not liable for any resulting adverse impact to you.
+
+11. Data privacy
+================
+
+11.1. To collect information about the usage of the App, while preserving as much user privacy as possible, we use cookie-less tracking in the App. We use this information to administer the App and we analyse this information to improve and enhance the App by expanding its features and functionality and tailoring it to our users’ needs and preferences. This includes tracking of App versions.
+
+11.2. When you create a Concordium Digital Identity Certificate (**“Identity Certificate”**) with a Third-Party Service, you will enter an agreement directly with such Third-Party Service and such Third-Party Service will store data about you. In this case, the Third-Party Service’s privacy policy and terms of use apply. The Third-Party Service may store a copy of the Identity Certificate for subsequent re-issuance; however, the Third-Party Service will not have access to your blockchain account address. The App stores the Identity Certificate in encrypted form, and it is not visible to us. You may choose to reveal and make publicly available any attributes associated with your account. However, if you reveal such attributes, these attributes will be visible on the blockchain, and can never be deleted.
+
+11.3. When you use  Remote Procedure Call (“RPC”) provider in the App to interact with a blockchain, certain information about you is collected. Depending on the RPC provider you use, your IP address and your blockchain account address when you send a transaction may be collected and your account address will be broadcasted to the Concordium blockchain.
+
+12. Governing law
+=================
+
+These Terms are governed by Swiss law. Any disputes arising under or in connection with these Terms, your use of the App is subject to the exclusive jurisdiction of the courts of the city of Zurich.
+
+13. Miscellaneous
+=================
+
+These Terms and any policies or operating rules posted by us on the App or in respect to the App constitute the entire agreement and understanding between you and us in relation to the App. Our failure to exercise or enforce any right or provision of these Terms shall not operate as a waiver of such right or provision. These Terms operate to the fullest extent permissible by law. We may assign any or all of our rights and obligations to others at any time. We shall not be responsible or liable for any loss, damage, delay, or failure to act caused by any cause beyond our reasonable control. If any provision or part of a provision of these Terms is determined to be unlawful, void, or unenforceable, that provision or part of the provision is deemed severable from these Terms and does not affect the validity and enforceability of any remaining provisions. There is no joint venture, partnership, employment, or agency relationship created between you and us as a result of these Terms or use of the App. You agree that these Terms will not be construed against us by virtue of having drafted them. You hereby waive any and all defences you may have based on the electronic form of these Terms and the lack of signing by the parties hereto to execute these Terms.
+
+14. Contact us
+==============
+
+To resolve a complaint regarding the App or to receive further information regarding use of the App, please contact us at: contact@concordium.software.

--- a/source/mainnet/docs/guides/wallets-lp.rst
+++ b/source/mainnet/docs/guides/wallets-lp.rst
@@ -16,3 +16,4 @@ Concordium offers its wallets for several different platforms, enabling you to m
     manage-wallets-lp
     account-activities-lp
     ../desktop-wallet/dw-lp
+    cryptox-terms


### PR DESCRIPTION
## Purpose

Restore End User License Terms for CryptoX which went missing recently.

## Changes

- Add the content of the terms to `docs/guides/cryptox-terms.html`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.