### PR TITLE
moved the page Web3 ID in the Concordium Wallet for Web into Wallet a…

### DIFF
--- a/source/mainnet/docs/guides/manage-wallets-lp.rst
+++ b/source/mainnet/docs/guides/manage-wallets-lp.rst
@@ -20,3 +20,4 @@ If you need to know how to send CCDs, recover your wallet on a new device, or mo
     show-seed-phrase
     show-wallet-private-key
     import-export-file
+    wallet.rst

--- a/source/mainnet/docs/guides/wallet.rst
+++ b/source/mainnet/docs/guides/wallet.rst
@@ -1,5 +1,5 @@
 .. _web3id-wallet:
-.. include:: ../../../variables.rst
+.. include:: ../../variables.rst
 
 .. meta::
     :description lang=en:
@@ -26,7 +26,7 @@ When choosing to add verifiable credentials from an issuer, make sure that you *
 
 #. The issuer sends a request to your |bw| to issue a verifiable credential. Click **Cancel** to stop the process or click **Add credential** to continue. You will see the verifiable credential as **Pending**.
 
-    .. image:: ../../../docs/images/browser-wallet/add-web3id-credential.png
+    .. image:: ../../docs/images/browser-wallet/add-web3id-credential.png
         :alt: window with pending credential and option buttons
         :width: 50%
 
@@ -38,7 +38,7 @@ To see the details of the verifiable credential:
 
 #. Click |actions-bw| and select **Details**.
 
-    .. image:: ../../../docs/images/browser-wallet/vc-details.png
+    .. image:: ../../docs/images/browser-wallet/vc-details.png
         :alt: window with card showing details of the verifiable credential
         :width: 50%
 
@@ -71,7 +71,7 @@ Recover verifiable credentials
 
 #. Click **Select file to import**. Navigate to the location that the *web3IdCredentials.export* file is located and select the file.
 
-    .. image:: ../../../docs/images/browser-wallet/vc-import.png
+    .. image:: ../../docs/images/browser-wallet/vc-import.png
         :alt: window with button to navigate to import file location
         :width: 50%
 
@@ -92,19 +92,19 @@ It is important to understand the difference between a proof request and a revea
 
 In the case below, the proof from the verifier is a mixed proof that requests you reveal the degree name and you prove that were born within a date range. This is a mixed proof because it asks you to reveal and prove information, and also because it asks to prove/reveal information from your verifiable credential and your account credential. Because your date of birth is not in the date range that statement cannot be proven and your only option is to reject the request. You never see the reveal request because you do not meet the requirement from the other part of the proof.
 
-.. image:: ../../../docs/images/browser-wallet/proof-not-proved.png
+.. image:: ../../docs/images/browser-wallet/proof-not-proved.png
     :alt: window with button to reject proof request
     :width: 50%
 
 Another example of a mixed proof includes a request to prove information from your verifiable credential and from your identity. The first screen is requesting you prove information from your verifiable credential. Click **Continue**.
 
-.. image:: ../../../docs/images/browser-wallet/vc-mixed-proof-1.png
+.. image:: ../../docs/images/browser-wallet/vc-mixed-proof-1.png
     :alt: window with verifiable credential proof and continue button
     :width: 50%
 
 The second screen is requesting you prove information from your account credential. You can choose which account (and thus identity) you want to use for the proof. Click **Approve** if you agree to prove the information. Click |reject| to reject the proof request.
 
-.. image:: ../../../docs/images/browser-wallet/vc-mixed-proof-2.png
+.. image:: ../../docs/images/browser-wallet/vc-mixed-proof-2.png
     :alt: window with account credential proof and approve button
     :width: 50%
 
@@ -126,14 +126,14 @@ These are just a few examples of how you might see proof requests in the |bw|, b
 
 
 
-.. |hamburger-bw| image:: ../../../docs/images/browser-wallet/hamburger-menu.png
+.. |hamburger-bw| image:: ../../docs/images/browser-wallet/hamburger-menu.png
     :width: 20px
     :alt: three horizontal lines
 
-.. |actions-bw| image:: ../../../docs/images/browser-wallet/page-actions.png
+.. |actions-bw| image:: ../../docs/images/browser-wallet/page-actions.png
                     :width: 20px
                     :alt: three horizontal lines
 
-.. |reject| image:: ../../../docs/images/browser-wallet/vc-reject-proof-button.png
+.. |reject| image:: ../../docs/images/browser-wallet/vc-reject-proof-button.png
                     :width: 20px
                     :alt: white x on red background

--- a/source/mainnet/docs/network/web3-id/index.rst
+++ b/source/mainnet/docs/network/web3-id/index.rst
@@ -101,7 +101,6 @@ An example verifier dApp is the `Concordia social media verifier on Testnet <htt
    :hidden:
    :maxdepth: 1
 
-   wallet
    issuer
    ../guides/create-proofs
    concordia


### PR DESCRIPTION
Activities

## Purpose

To move the page Web3 ID in the Concordium Wallet for Web into the wallet documentation in accordance with [DOC-307](https://linear.app/concordium/issue/DOC-307/move-web3-id-in-the-concordium-wallet-for-web-into-wallet-for-web)

## Changes

Moved the page under the section Wallet activities.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf


