### PR TITLE
Download links and release notes for 8.0.3 node.

### DIFF
--- a/source/mainnet/docs/installation/downloads.rst
+++ b/source/mainnet/docs/installation/downloads.rst
@@ -216,9 +216,9 @@ For the system requirements to run a node, see :ref:`System requirements to run 
 
    .. dropdown:: Ubuntu |testnet-node-version|
 
-      To run a node on a server with Ubuntu, `download a Testnet Debian package <https://distribution.testnet.concordium.com/deb/concordium-testnet-node_7.0.5-0_amd64.deb>`_.
+      To run a node on a server with Ubuntu, `download a Testnet Debian package <https://distribution.testnet.concordium.com/deb/concordium-testnet-node_8.0.3-1_amd64.deb>`_.
 
-      - SHA256 checksum of the download: ``73a3ec82b7857f068d9f3a457d4e49658d99a5817d163031b4afdc7078f9aafe``
+      - SHA256 checksum of the download: ``168a2991140f99845bb2289156d03d14eed8a441ba331f729d365f7220ffb869``
 
       To learn how to run a node with Ubuntu, see :ref:`Run a node on a server with Ubuntu <run-node-ubuntu>`.
 
@@ -232,13 +232,13 @@ For the system requirements to run a node, see :ref:`System requirements to run 
 
    .. dropdown:: Windows |testnet-node-version|
 
-      To run a node on Windows, `download a Testnet Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-7.0.5-0.msi>`_. **Please be aware that you should backup your configuration, as the installer will overwrite the current configuration with a standard configuration.**
+      To run a node on Windows, `download a Testnet Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-8.0.3-1.msi>`_. **Please be aware that you should backup your configuration, as the installer will overwrite the current configuration with a standard configuration.**
 
       To learn how to run a node on Windows, see :ref:`Run and manage a node on Windows <run-node-windows>`.
 
    .. dropdown:: Mac |testnet-node-version|
 
-      To run a node on macOS, `download a Testnet macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-7.0.5.pkg>`_.
+      To run a node on macOS, `download a Testnet macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-8.0.3-1.pkg>`_.
 
       To learn how to run a node on Mac, see :ref:`Run and manage a node on macOS <run-node-macos>`.
 

--- a/source/mainnet/docs/installation/previous-node-downloads.rst
+++ b/source/mainnet/docs/installation/previous-node-downloads.rst
@@ -258,6 +258,16 @@ Ubuntu - Testnet
 Default GRPC port is set to 20001
 Default listen port is set to 8889
 
+`7.0.5 <https://distribution.testnet.concordium.com/deb/concordium-testnet-node_7.0.5-0_amd64.deb>`
+
+   - Verification instructions
+
+      In a terminal:
+
+      #. Navigate to the download.
+      #. Paste the following into the terminal: $sha256sum concordium-testnet-node_7.0.5-0_amd64.deb
+      #. Verify that the output matches the SHA256 checksum ``73a3ec82b7857f068d9f3a457d4e49658d99a5817d163031b4afdc7078f9aafe``
+
 `7.0.4 <https://distribution.testnet.concordium.com/deb/concordium-testnet-node_7.0.4-0_amd64.deb>`__
 
    - Verification instructions

--- a/source/mainnet/docs/release-notes/release-notes-lp.rst
+++ b/source/mainnet/docs/release-notes/release-notes-lp.rst
@@ -1132,12 +1132,48 @@ Mainnet
 Testnet
 -------
 
-    September 30, 2024
+    February 18, 2024
 
-    Concordium node version 7.0.5 fixes a bug in the handling of smart contract names that could cause the node to crash.
-    **This is a critical bug fix, and node runners should update as soon as possible.**
+    Concordium node version 8.0.3 contains support for `protocol version 8 <https://proposals.concordium.software/updates/P8.html>`_.
+    The new consensus protocol will take effect on the testnet on February 24, 2025.
+    **Node runners should upgrade to version 8.0.3 before the protocol update to ensure that their nodes do not shut down.**
+    Validators in particular are encouraged to update their nodes, as the new protocol introduces suspension of inactive validators, meaning that failing to update may result in your validator being suspended.
+
+    Protocol version 8 introduces the following changes:
+
+        - Validators are automatically suspended if they do not produce blocks for a certain number of rounds.
+
+        - The configure-validator transaction can suspend or resume a validator, including adding a validator in a suspended state.
+
+        - Suspended validators are paused from participating in the consensus algorithm.
+
+    Additionally, the node release includes a number of fixes and improvements:
+
+        - Add suspension info to `BakerPoolStatus` / `CurrentPaydayBakerPoolStatus` query results.
+
+        - Add `GetConsensusDetailedStatus` gRPC endpoint for getting detailed information on the status of the consensus, at consensus version 1.
+
+        - Update Rust version to 1.82.
+
+        - Update GHC version to 9.6.6 (LTS-22.39).
+
+        - Add `GetScheduledReleaseAccounts` endpoint for querying the list of accounts that have scheduled releases.
+
+        - Add `GetCooldownAccounts`, `GetPreCooldownAccounts` and `GetPrePreCooldownAccounts` endpoints for querying the lists of accounts that have pending cooldowns in protocol version 7 onwards.
+
+        - gRPC endpoints `DryRun`, `GetBlockItemStatus` and `GetBlockTransactionEvents` now report the parameter used to initialize a smart contract instance as part of a `ContractInitializedEvent`.
+
+        - Fix a bug where, after a protocol update in consensus version 1 (P6 onwards), a node may miscalculate the absolute height of blocks when it is restarted.
+
+        - Fix a bug where `GetBlockInfo` reports the parent block of a genesis block to be the last finalized block of the previous genesis index, instead of the terminal block.
+
 
     .. dropdown:: Previous releases
+
+        .. dropdown:: 7.0.5 - September 30, 2024
+
+            Concordium node version 7.0.5 fixes a bug in the handling of smart contract names that could cause the node to crash.
+            **This is a critical bug fix, and node runners should update as soon as possible.**
 
         .. dropdown:: 7.0.4 - September 23, 2024
 

--- a/source/mainnet/variables.rst
+++ b/source/mainnet/variables.rst
@@ -25,7 +25,7 @@
 
 .. Node version variables
 .. |mainnet-node-version| replace:: 7.0.5
-.. |testnet-node-version| replace:: 7.0.5
+.. |testnet-node-version| replace:: 8.0.3
 
 .. Node debian package verification variables
 .. |node-deb-package| replace:: concordium-mainnet-node_7.0.5-0_amd64.deb


### PR DESCRIPTION
## Purpose

Release node version 8.0.3 for testnet.

## Changes

- Download links
- Hashes
- Release notes
- Old download links.