### PR TITLE
Release node 8.0.3 for mainnet.

### DIFF
--- a/source/mainnet/docs/installation/downloads.rst
+++ b/source/mainnet/docs/installation/downloads.rst
@@ -187,7 +187,7 @@ For the system requirements to run a node, see :ref:`System requirements to run 
 
    .. dropdown:: Ubuntu |mainnet-node-version|
 
-      To run a node on a server with Ubuntu, `download a Mainnet Debian package <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_7.0.5-0_amd64.deb>`_.
+      To run a node on a server with Ubuntu, `download a Mainnet Debian package <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_8.0.3-1_amd64.deb>`_.
 
          - SHA256 checksum of the download: |node-deb-package-checksum|
 
@@ -199,13 +199,13 @@ For the system requirements to run a node, see :ref:`System requirements to run 
 
    .. dropdown:: Windows |mainnet-node-version|
 
-      To run a node on Windows, `download a Mainnet Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-7.0.5-0.msi>`_. **Please be aware that you should backup your configuration, as the installer will overwrite the current configuration with a standard configuration.**
+      To run a node on Windows, `download a Mainnet Windows Installer package <https://distribution.concordium.software/windows/Signed/Node-8.0.3-1.msi>`_. **Please be aware that you should backup your configuration, as the installer will overwrite the current configuration with a standard configuration.**
 
       To learn how to run a node on Windows, see :ref:`Run and manage a node on Windows <run-node-windows>`.
 
    .. dropdown:: Mac |mainnet-node-version|
 
-      To run a node on macOS, `download a Mainnet macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-7.0.5.pkg>`_.
+      To run a node on macOS, `download a Mainnet macOS installer package <https://distribution.concordium.software/macos/signed/concordium-node-8.0.3-1.pkg>`_.
 
       To learn how to run a node on Mac, see :ref:`Run and manage a node on macOS  <run-node-macos>`.
 

--- a/source/mainnet/docs/installation/previous-node-downloads.rst
+++ b/source/mainnet/docs/installation/previous-node-downloads.rst
@@ -105,6 +105,16 @@ Ubuntu - Mainnet
 Default GRPC port is set to 20000
 Default listen port is set to 8888
 
+`7.0.5 <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_7.0.5-0_amd64.deb>`__
+
+   - Verification instructions
+
+      In a terminal:
+
+      #. Navigate to the download.
+      #. Paste the following into the terminal: $sha256sum concordium-testnet-node_7.0.5-0_amd64.deb
+      #. Verify that the output matches the SHA256 checksum ``42bb05409561bc30917d87a3479d3b76d9a3f17fa46bb2aee7475e7f7fa1df5d``
+
 `6.3.0 <https://distribution.mainnet.concordium.software/deb/concordium-mainnet-node_6.3.0-0_amd64.deb>`__
 
    - Verification instructions

--- a/source/mainnet/docs/release-notes/release-notes-lp.rst
+++ b/source/mainnet/docs/release-notes/release-notes-lp.rst
@@ -689,43 +689,78 @@ Nodes
 Mainnet
 -------
 
-    October 3, 2024
+    March 3, 2025
 
-    Concordium node version 7.0.5 contains support for `protocol version 7 <https://proposals.concordium.software/updates/P7.html>`_.
-    The new consensus protocol will take effect on the mainnet on October 30, 2024.
-    **Node runners should upgrade to version 7.0.5 before the protocol update to ensure that their nodes do not shut down.**
+    Concordium node version 8.0.3 contains support for `protocol version 8 <https://proposals.concordium.software/updates/P8.html>`_.
+    The new consensus protocol will take effect on the mainnet on March 17, 2025.
+    **Node runners should upgrade to version 8.0.3 before the protocol update to ensure that their nodes do not shut down.**
+    Validators in particular are encouraged to update their nodes, as the new protocol introduces suspension of inactive validators, meaning that failing to update may result in your validator being suspended.
 
-    Protocol version 7 introduces the following changes:
+    Protocol version 8 introduces the following changes:
 
-    - The cool-down behavior when the stake of a validator or delegator is reduced or removed is changed:
+        - Validators are automatically suspended if they do not produce blocks for a certain number of rounds.
 
-        - When stake is reduced, the reduction is immediately effective for future stake calculations, and the amount of the reduction is locked for a cool-down period.
-            (Previously, the reduction was only effective after the cool-down period.)
+        - The configure-validator transaction can suspend or resume a validator, including adding a validator in a suspended state.
 
-        - Validators and delegators can make further changes to their stake while they already have stake in cooldown.
-            This includes registering as a validator when the account was previously a delegator, or vice versa.
-            (Previously, the account had to wait for the cool-down period to end before making further changes.)
+        - Suspended validators are paused from participating in the consensus algorithm.
 
-    - Shielded transfers are no longer supported in the protocol.
-        It is still possible to unshield a previously shielded balance.
+    Additionally, the node release includes a number of fixes and improvements:
 
-    - Smart contract execution costs are reduced.
-        This reflects a more efficient implementation of the smart contract execution engine introduced in this release.
+        - Add suspension info to `BakerPoolStatus` / `CurrentPaydayBakerPoolStatus` query results.
 
-    - Smart contracts can now query the module reference and contract name of a smart contract instance.
+        - Add `GetConsensusDetailedStatus` gRPC endpoint for getting detailed information on the status of the consensus, at consensus version 1.
 
-    - The block hashing scheme is redefined to better support light clients.
+        - Update Rust version to 1.82.
 
-    Additionaly, the node release includes a number of fixes and improvements:
+        - Update GHC version to 9.6.6 (LTS-22.39).
 
-    - Logging around protocol updates is improved.
-    - Failed gRPC requests are now logged at ``DEBUG`` level.
-    - Fixed a bug where ``GetBakersRewardPeriod`` returns incorrect data.
-    - Fixed a bug where ``GetPoolInfo`` returns incorrect data.
-    - Fixed a bug where a configure-validator transaction that is rejected for having a duplicate aggregation key reports the old key of the validator, rather than the new (duplicative) key.
-    - Improved the behavior of the node in the event of an unrecoverable error in consensus.
+        - Add `GetScheduledReleaseAccounts` endpoint for querying the list of accounts that have scheduled releases.
+
+        - Add `GetCooldownAccounts`, `GetPreCooldownAccounts` and `GetPrePreCooldownAccounts` endpoints for querying the lists of accounts that have pending cooldowns in protocol version 7 onwards.
+
+        - gRPC endpoints `DryRun`, `GetBlockItemStatus` and `GetBlockTransactionEvents` now report the parameter used to initialize a smart contract instance as part of a `ContractInitializedEvent`.
+
+        - Fix a bug where, after a protocol update in consensus version 1 (P6 onwards), a node may miscalculate the absolute height of blocks when it is restarted.
+
+        - Fix a bug where `GetBlockInfo` reports the parent block of a genesis block to be the last finalized block of the previous genesis index, instead of the terminal block.
 
     .. dropdown:: Previous releases
+
+        .. dropdown:: 7.0.5 - October 3, 2024
+
+            Concordium node version 7.0.5 contains support for `protocol version 7 <https://proposals.concordium.software/updates/P7.html>`_.
+            The new consensus protocol will take effect on the mainnet on October 30, 2024.
+            **Node runners should upgrade to version 7.0.5 before the protocol update to ensure that their nodes do not shut down.**
+
+            Protocol version 7 introduces the following changes:
+
+            - The cool-down behavior when the stake of a validator or delegator is reduced or removed is changed:
+
+                - When stake is reduced, the reduction is immediately effective for future stake calculations, and the amount of the reduction is locked for a cool-down period.
+                    (Previously, the reduction was only effective after the cool-down period.)
+
+                - Validators and delegators can make further changes to their stake while they already have stake in cooldown.
+                    This includes registering as a validator when the account was previously a delegator, or vice versa.
+                    (Previously, the account had to wait for the cool-down period to end before making further changes.)
+
+            - Shielded transfers are no longer supported in the protocol.
+                It is still possible to unshield a previously shielded balance.
+
+            - Smart contract execution costs are reduced.
+                This reflects a more efficient implementation of the smart contract execution engine introduced in this release.
+
+            - Smart contracts can now query the module reference and contract name of a smart contract instance.
+
+            - The block hashing scheme is redefined to better support light clients.
+
+            Additionaly, the node release includes a number of fixes and improvements:
+
+            - Logging around protocol updates is improved.
+            - Failed gRPC requests are now logged at ``DEBUG`` level.
+            - Fixed a bug where ``GetBakersRewardPeriod`` returns incorrect data.
+            - Fixed a bug where ``GetPoolInfo`` returns incorrect data.
+            - Fixed a bug where a configure-validator transaction that is rejected for having a duplicate aggregation key reports the old key of the validator, rather than the new (duplicative) key.
+            - Improved the behavior of the node in the event of an unrecoverable error in consensus.
 
         .. dropdown:: 6.3.2 - September 30, 2024
 

--- a/source/mainnet/docs/release-notes/release-notes-lp.rst
+++ b/source/mainnet/docs/release-notes/release-notes-lp.rst
@@ -769,7 +769,7 @@ Mainnet
 
         .. dropdown:: 6.3.1 - June 24, 2024
 
-        Concordium node version 6.3.1 fixes a bug where a node may fail to produce a timeout certificate due to incorrectly computing the total weight of finalizers that have signed timeout messages.
+            Concordium node version 6.3.1 fixes a bug where a node may fail to produce a timeout certificate due to incorrectly computing the total weight of finalizers that have signed timeout messages.
 
         .. dropdown:: 6.3.0 - February 27, 2024
 

--- a/source/mainnet/variables.rst
+++ b/source/mainnet/variables.rst
@@ -24,12 +24,12 @@
 .. |cargo-linux-checksum| replace:: ea3f603e2a921181cdf323604066444378a955c55e82b206a7d169bf636fa75d
 
 .. Node version variables
-.. |mainnet-node-version| replace:: 7.0.5
+.. |mainnet-node-version| replace:: 8.0.3
 .. |testnet-node-version| replace:: 8.0.3
 
 .. Node debian package verification variables
-.. |node-deb-package| replace:: concordium-mainnet-node_7.0.5-0_amd64.deb
-.. |node-deb-package-checksum| replace:: 42bb05409561bc30917d87a3479d3b76d9a3f17fa46bb2aee7475e7f7fa1df5d
+.. |node-deb-package| replace:: concordium-mainnet-node_8.0.3-1_amd64.deb
+.. |node-deb-package-checksum| replace:: 83216d9985971f3dec3d3e99da3822e01e022558887e2461c0cb315d48bd0460
 
 .. Mainnet genesis block verification variables
 .. |mainnet-genesis-block| replace:: genesis.dat


### PR DESCRIPTION
## Purpose

Release node version 8.0.3 for mainnet.

## Changes

- Update release notes.
- Update download links.
- Update checksum.
- Update old download links.
