### PR TITLE
Update cargo concordium version

### DIFF
--- a/source/mainnet/docs/index.rst
+++ b/source/mainnet/docs/index.rst
@@ -60,13 +60,13 @@ Explore our developer resources, including detailed documentation, tutorials, an
 
 .. Note::
 
-   Currently, Rust toolchain versions up to ``1.81`` are and newer are not supported by older ``cargo-concordium`` versions ( < ``4.1.0``). Update cargo-concordium if you see the error ``Unexpected byte 0x80. Expected 0x00`` as follows:
+   Currently, Rust toolchain versions up to ``1.81`` are and newer are not supported by older ``cargo-concordium`` versions ( <= ``4.0.0``). Update ``cargo-concordium`` if you see the error ``Unexpected byte 0x80. Expected 0x00`` as follows:
 
    .. code-block:: console
 
       $ cargo install cargo-concordium
       $ cargo concordium --version
-      $ cargo-concordium 4.1.0
+      $ cargo-concordium 4.1.1
 
    The minimum supported rust version is currently version ``1.73``
 

--- a/source/mainnet/docs/smart-contracts/guides/build-contract.rst
+++ b/source/mainnet/docs/smart-contracts/guides/build-contract.rst
@@ -30,13 +30,13 @@ machine.
 
 .. Note::
 
-   Currently, Rust toolchain versions up to ``1.81`` are and newer are not supported by older ``cargo-concordium`` versions ( < ``4.1.0``). Update cargo-concordium if you see the error ``Unexpected byte 0x80. Expected 0x00`` as follows:
+   Currently, Rust toolchain versions up to ``1.81`` are and newer are not supported by older ``cargo-concordium`` versions ( <= ``4.0.0``). Update ``cargo-concordium`` if you see the error ``Unexpected byte 0x80. Expected 0x00`` as follows:
 
    .. code-block:: console
 
       $ cargo install cargo-concordium
       $ cargo concordium --version
-      $ cargo-concordium 4.1.0
+      $ cargo-concordium 4.1.1
 
    The minimum supported rust version is currently version ``1.73``
 

--- a/source/shared/setup-env.rst
+++ b/source/shared/setup-env.rst
@@ -28,13 +28,13 @@ Finally, when Rust and Cargo are successfully installed in your system, you shou
 
 .. Note::
 
-   Currently, Rust toolchain versions up to ``1.81`` are and newer are not supported by older ``cargo-concordium`` versions ( < ``4.1.0``). Update cargo-concordium if you see the error ``Unexpected byte 0x80. Expected 0x00`` as follows:
+   Currently, Rust toolchain versions up to ``1.81`` are and newer are not supported by older ``cargo-concordium`` versions ( <= ``4.0.0``). Update ``cargo-concordium`` if you see the error ``Unexpected byte 0x80. Expected 0x00`` as follows:
 
    .. code-block:: console
 
       $ cargo install cargo-concordium
       $ cargo concordium --version
-      $ cargo-concordium 4.1.0
+      $ cargo-concordium 4.1.1
 
    The minimum supported rust version is currently version ``1.73``
 


### PR DESCRIPTION
## Purpose

- `cargo-concordium` version 4.1.0 got yanked on `crates.io` and should not be used.

https://crates.io/crates/cargo-concordium/versions

## Purpose

- Update comments to use version 4.1.1