### PR TITLE
added new Concordia page with explainer

### DIFF
--- a/source/mainnet/conf.py
+++ b/source/mainnet/conf.py
@@ -635,5 +635,4 @@ redirects = {
     "net/guides/legal" : "/en/mainnet/docs/guides/cryptox-terms.html",
     "net/guides/export-key" : "/en/mainnet/docs/guides/export-key.html",
     "smart-contracts/guides/on-chain-index" : "/en/mainnet/docs/smart-contracts/introduction.html",
-    "docs/network/web3-id/concordia" : "/en/mainnet/docs/index.html"
     }

--- a/source/mainnet/docs/network/guides/create-proofs.rst
+++ b/source/mainnet/docs/network/guides/create-proofs.rst
@@ -8,7 +8,7 @@ Create proofs
 A :term:`verifier` is a business or use-case that provides a service contingent on the holder providing information about themselves using :term:`verifiable credentials<verifiable credential>` or :term:`account credentials<account credential>` they have. A verifier will typically consist of two components:
 
 1. A dApp that interacts with the wallet and requests a :term:`verifiable presentation` from the user.
-2. A backend that will verify the provided presentations, and provide the required service if successful, such as the `Concordia backend <https://github.com/Concordium/concordium-web3id/tree/main/examples/some-verifier>`_.
+2. A backend that will verify the provided presentations, and provide the required service if successful.
 
 The |bw| allows verifiers to request verifiable presentations using dApps or services that the user meets some requirement, such as proof the user is over a certain age, or resides in a specific set of countries or area. The wallet owner chooses whether to prove these :term:`attributes<attributes>` to the dApp or service. The dApp or service constructs a list of :term:`statements<statement>` to request a corresponding list of :term:`zero-knowledge proofs<zero-knowledge proof>` of the attribute(s) necessary without revealing anything beyond the truth of the statement. Presentations contain zero-knowledge proofs.
 

--- a/source/mainnet/docs/network/web3-id/concordia.rst
+++ b/source/mainnet/docs/network/web3-id/concordia.rst
@@ -1,0 +1,16 @@
+:orphan:
+
+Concordia
+=========
+
+Important Update
+----------------
+
+.. important::
+
+    The Concordia bot service is currently offline. However, the complete codebase remains available as an open source project. You can access the code and examples at https://github.com/Concordium/concordium-web3id/tree/9bb3b1945490d152df2c84f9bd7ce9f463c42e64/examples.
+
+About Concordia
+---------------
+
+Concordia was a Web3 ID solution that allowed users to transfer trust between Telegram and Discord using verifiable credentials in the Concordium Wallet. Users could prove ownership of their social media accounts, link them to their identity, and verify other users across platforms with commands like ``/check`` and ``/verify``.

--- a/source/mainnet/docs/network/web3-id/concordia.rst
+++ b/source/mainnet/docs/network/web3-id/concordia.rst
@@ -14,3 +14,4 @@ About Concordia
 ---------------
 
 Concordia was a Web3 ID solution that allowed users to transfer trust between Telegram and Discord using verifiable credentials in the Concordium Wallet. Users could prove ownership of their social media accounts, link them to their identity, and verify other users across platforms with commands like ``/check`` and ``/verify``.
+

--- a/source/mainnet/docs/network/web3-id/index.rst
+++ b/source/mainnet/docs/network/web3-id/index.rst
@@ -70,7 +70,7 @@ Issuer
 An issuer will typically consist of the following components.
 
 1. Some existing way of identifying users.
-2. A dApp that integrates with the wallet and allows the holder to request credential. An example dApp is the `Concordia social media verifier on Testnet <https://concordia.testnet.concordium.com/>`_.
+2. A dApp that integrates with the wallet and allows the holder to request credential.
 3. A smart contract that manages the credential lifetime. When a verifiable credential is issued the metadata is stored in the contract, and the attributes and other secrets, the full verifiable credential, are returned to the dApp to be stored in the wallet.
 
 To ease the process of becoming an issuer, Concordium has created the `Concordium Web3 ID Issuer Frontend <https://web3id-issuer-onboarding.mainnet.concordium.software/>`__ where you can quickly and easily become an issuer.
@@ -95,7 +95,7 @@ In particular, a key part of the business logic is whether the verifier trusts a
 
 Concordium runs an instance of the verifier for `Mainnet <https://web3id-verifier.mainnet.concordium.software/v0/verify>`_ or `Testnet <https://web3id-verifier.testnet.concordium.com/v0/verify>`__. Using Concordium hosted services means that the verifier places trust in Concordium, but simplifies the implementation of the verifier. You still have to provide a user interface or frontend (usually a dApp) that calls the Concordium hosted verifier. Otherwise, if you want to run the verification service yourself, Concordium simplifies the checking of the cryptographic part by providing a `verifier service <https://github.com/Concordium/concordium-web3id/tree/main/services/web3id-verifier>`_. To read more about the verification service, see :ref:`Tool to verify credentials<verifier-tool>`.
 
-An example verifier dApp is the `Concordia social media verifier on Testnet <https://concordia.testnet.concordium.com/>`_, and an example backend can be found in `the Web3 ID repository <https://github.com/Concordium/concordium-web3id/tree/main/examples/some-verifier>`__.
+An example backend can be found in `the Web3 ID repository <https://github.com/Concordium/concordium-web3id/tree/main/examples/some-verifier>`__.
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
## Purpose

To add a page explaining that Concordia bot is offline, but the code is open source and available via link on page.

## Changes

- Added new concordia.rst page (the earlier page was removed)
- Updated conf.py (removed earlier added redirect since the new explainer page has the same address as the old concordia page)


## Checklist

- [x ] My code follows the style of this project.
- [x ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf
