### PR TITLE
Remove link that would open verifier backend endpoints in browser

### DIFF
--- a/source/mainnet/docs/network/guides/create-proofs.rst
+++ b/source/mainnet/docs/network/guides/create-proofs.rst
@@ -189,7 +189,19 @@ The verifier has a single POST endpoint and is meant to be used by another servi
 
 The response to the request will be status code 200 together with a JSON body that contains the request (i.e., challenge and statement for which the presentation is valid) together with the timestamp and block in which the verification took place. In case of an invalid request the HTTP status code will be in the 4** range, either 404 if credentials cannot be found, or 400 for invalid proofs or otherwise malformed requests.
 
-You can choose whether you want to use the hosted Concordium verifier for `Mainnet <https://web3id-verifier.mainnet.concordium.software/v0/verify>`__ or `Testnet <https://web3id-verifier.testnet.concordium.com/v0/verify>`__, or whether you want to create your own verifier tool. Note that if you use the hosted verifier then you trust Concordium when verifying proofs.
+You can choose whether you want to run your own verifier tool or you want to use the hosted Concordium verifier endpoints:
+
+- Mainnet: `https://web3id-verifier.mainnet.concordium.software/v0/verify`
+
+- Testnet: `https://web3id-verifier.testnet.concordium.com/v0/verify`
+
+An example request sent to the endpoint is as follows:
+
+.. code-block:: console
+
+    curl -POST "https://web3id-verifier.testnet.concordium.com/v0/verify" -H "Content-Type: application/json" --data '{"presentationContext":"759426830fd65e1ad30585fb8dc14cbf9f643a825e28196b896ee36c6f85fe33","proof":{"created":"2025-04-07T07:57:46.644Z","proofValue":[],"type":"ConcordiumWeakLinkingProofV1"},"type":"VerifiablePresentation","verifiableCredential":[{"credentialSubject":{"id":"did:ccd:testnet:cred:b1f1b7bb1b57af17cfcdfa853da3401456e985d8f9dc42178007aa2eef6a89f0b0bb467673fa0baff2d82c98fca6c5ef","proof":{"created":"2025-04-07T07:57:46.644Z","proofValue":[{"attribute":"John","proof":"7f4c5f378aef48e636979ca20adaa8b4d54c4518102c4d5991e1d794a4e9ba3f59855b40ce1175be7d23c09c056064c92dab7cb140508735b8922f5eaac2cb1a","type":"RevealAttribute"}],"type":"ConcordiumZKProofV3"},"statement":[{"attributeTag":"firstName","type":"RevealAttribute"}]},"issuer":"did:ccd:testnet:idp:0","type":["VerifiableCredential","ConcordiumVerifiableCredential"]}]}' -v
+
+Note that if you use the hosted verifier then you trust Concordium when verifying proofs.
 
 If you do not wish to use the Concordium hosted verifier, you can can either build your own following instructions in `readme file <https://github.com/Concordium/concordium-web3id/tree/main/services/web3id-verifier>`__ or use the `published Docker image <https://hub.docker.com/r/concordium/web3id-verifier/tags>`__.
 


### PR DESCRIPTION
## Purpose

https://concordium.slack.com/archives/C03DRCC9GR1/p1743014600943049

Remove link that used to open the backend verifier endpoints in the browser that often caused confusion to readers because they thought the `link/service` was broken.

![Screenshot from 2025-04-07 10-06-26](https://github.com/user-attachments/assets/43fdf8ff-f1d4-478a-a6e9-3268220bac1a)

## Changes

