### PR TITLE
added PL T documentation structure to Community section

### DIFF
--- a/source/mainnet/community/index.rst
+++ b/source/mainnet/community/index.rst
@@ -43,5 +43,6 @@ Office Hours
    :hidden:
 
    DevNet <devnet>
+   Protocol Layer Tokens (PLTs) <plt/index>
    Developer Spotlight <developer-spotlight/index>
    Office Hours <office-hours/index>

--- a/source/mainnet/community/plt/index.rst
+++ b/source/mainnet/community/plt/index.rst
@@ -1,0 +1,17 @@
+.. _plts:
+
+Protocol Layer Tokens (PLTs)
+===========================
+
+Protocol Layer Tokens (PLTs) are Concordium's native token standard built directly into the blockchain protocol layer. Unlike smart contract tokens, PLTs benefit from enhanced security, lower transaction costs, and direct integration with the Concordium identity layer.
+
+Currently available on DevNet for testing and experimentation, PLTs enable new possibilities for digital assets on Concordium.
+
+
+
+.. toctree::
+   :maxdepth: 1
+
+   setup-guide/index
+   operations/index
+   integration-guide/index

--- a/source/mainnet/community/plt/integration-guide/concordium-client.rst
+++ b/source/mainnet/community/plt/integration-guide/concordium-client.rst
@@ -1,0 +1,8 @@
+.. _plt-concordium-client:
+
+Using concordium-client with PLTs
+=================================
+
+This guide demonstrates how to interact with Protocol Layer Tokens using the Concordium command-line client.
+
+[Content will be expanded here]

--- a/source/mainnet/community/plt/integration-guide/index.rst
+++ b/source/mainnet/community/plt/integration-guide/index.rst
@@ -1,0 +1,13 @@
+.. _plt-integration:
+
+PLT Integration Guide
+=====================
+
+This section provides guidance on integrating Protocol Layer Tokens (PLTs) using various tools and SDKs provided by Concordium.
+
+.. toctree::
+   :maxdepth: 1
+
+   concordium-client
+   web-sdk
+   rust-sdk

--- a/source/mainnet/community/plt/integration-guide/rust-sdk.rst
+++ b/source/mainnet/community/plt/integration-guide/rust-sdk.rst
@@ -1,0 +1,8 @@
+.. _plt-rust-sdk:
+
+Rust SDK Integration
+===================
+
+This guide shows how to work with Protocol Layer Tokens using Concordium's Rust SDK.
+
+[Content will be expanded here]

--- a/source/mainnet/community/plt/integration-guide/web-sdk.rst
+++ b/source/mainnet/community/plt/integration-guide/web-sdk.rst
@@ -1,0 +1,8 @@
+.. _plt-web-sdk:
+
+Web SDK Integration
+===================
+
+Learn how to integrate Protocol Layer Tokens into web applications using Concordium's Web SDK.
+
+[Content will be expanded here]

--- a/source/mainnet/community/plt/operations/create-plt.rst
+++ b/source/mainnet/community/plt/operations/create-plt.rst
@@ -1,0 +1,8 @@
+.. _plt-create:
+
+Creating PLTs
+=============
+
+This guide explains the process of creating Protocol Layer Tokens (PLTs) on Concordium's DevNet through the governance process.
+
+[Content will be expanded here]

--- a/source/mainnet/community/plt/operations/index.rst
+++ b/source/mainnet/community/plt/operations/index.rst
@@ -1,0 +1,13 @@
+.. _plt-operations:
+
+PLT Operations
+=============
+
+This section covers the core operations available with Protocol Layer Tokens (PLTs) on Concordium's DevNet.
+
+.. toctree::
+   :maxdepth: 1
+
+   create-plt
+   transfer-plt
+   query-plt

--- a/source/mainnet/community/plt/operations/query-plt.rst
+++ b/source/mainnet/community/plt/operations/query-plt.rst
@@ -1,0 +1,8 @@
+.. _plt-query:
+
+Querying PLT Information
+========================
+
+This guide covers how to query information about Protocol Layer Tokens, including token lists, token details, and account balances.
+
+[Content will be expanded here]

--- a/source/mainnet/community/plt/operations/transfer-plt.rst
+++ b/source/mainnet/community/plt/operations/transfer-plt.rst
@@ -1,0 +1,8 @@
+.. _plt-transfer:
+
+Transferring PLTs
+=================
+
+Learn how to transfer Protocol Layer Tokens (PLTs) between accounts on Concordium's DevNet.
+
+[Content will be expanded here]

--- a/source/mainnet/community/plt/setup-guide/browser-wallet.rst
+++ b/source/mainnet/community/plt/setup-guide/browser-wallet.rst
@@ -1,0 +1,8 @@
+.. _plt-browser-wallet:
+
+Browser Wallet Setup for DevNet
+===============================
+
+This guide walks you through downloading and installing the DevNet Browser Wallet, which allows you to connect to Concordium's DevNet environment and work with Protocol Layer Tokens.
+
+[Content will be expanded here]

--- a/source/mainnet/community/plt/setup-guide/devnet-connection.rst
+++ b/source/mainnet/community/plt/setup-guide/devnet-connection.rst
@@ -1,0 +1,8 @@
+.. _plt-devnet-connection:
+
+Connecting to DevNet
+===================
+
+Learn how to configure your Browser Wallet to connect to Concordium's DevNet environment with the proper settings and parameters.
+
+[Content will be expanded here]

--- a/source/mainnet/community/plt/setup-guide/index.rst
+++ b/source/mainnet/community/plt/setup-guide/index.rst
@@ -1,0 +1,14 @@
+.. _plt-setup-guide:
+
+Getting Started with PLT DevNet
+===============================
+
+This section covers everything you need to get started with Protocol Layer Tokens (PLTs) on Concordium's DevNet. Follow these steps to set up your environment and begin working with PLTs.
+
+.. toctree::
+   :maxdepth: 1
+
+   browser-wallet
+   devnet-connection
+   request-ccd
+   request-plt

--- a/source/mainnet/community/plt/setup-guide/request-ccd.rst
+++ b/source/mainnet/community/plt/setup-guide/request-ccd.rst
@@ -1,0 +1,8 @@
+.. _plt-request-ccd:
+
+Getting Test CCD on DevNet
+=========================
+
+This guide explains how to request test CCD tokens on DevNet, which are required for transactions and PLT operations.
+
+[Content will be expanded here]

--- a/source/mainnet/community/plt/setup-guide/request-plt.rst
+++ b/source/mainnet/community/plt/setup-guide/request-plt.rst
@@ -1,0 +1,8 @@
+.. _plt-request-plt:
+
+Requesting PLT Issuance
+======================
+
+Learn how to request the issuance of your own Protocol Layer Token (PLT) through the DevNet PLT issuance form.
+
+[Content will be expanded here]


### PR DESCRIPTION
## Purpose

Adds the initial structure for Protocol Layer Tokens (PLTs) documentation under the Community section.

## Changes

- Created main PLT overview page for general information
- Added Getting Started with PLT DevNet section for setup guides
- Added PLT Operations section for documenting core functionality
- Added PLT Integration Guide section for SDK and CLI documentation


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

