### PR TITLE
Fix terminology issues

### DIFF
--- a/source/mainnet/conf.py
+++ b/source/mainnet/conf.py
@@ -644,5 +644,6 @@ redirects = {
     "net/references/net/references/grpc2" : "/en/mainnet/tools/grpc2.html",
     "guides/export-import": "/en/mainnet/docs/guides/recovery.html",
     "guides/recover-wallet": "/en/mainnet/docs/guides/recovery.html",
-    "docs/protocol/id-accounts": "/en/mainnet/docs/protocol/identity.html"
+    "docs/protocol/id-accounts": "/en/mainnet/docs/protocol/identity.html",
+    "docs/network/guides/become-baker": "en/mainnet/docs/network/guides/become-validator.html"
     }

--- a/source/mainnet/docs/network/baker-pool.rst
+++ b/source/mainnet/docs/network/baker-pool.rst
@@ -52,7 +52,7 @@ The tool for both validator management and research is `CCDScan <https://ccdscan
    guides/baker-macos
    guides/baker-ubuntu
    guides/baker-docker
-   guides/become-baker
+   guides/become-validator
 
 
 

--- a/source/mainnet/docs/network/guides/become-validator.rst
+++ b/source/mainnet/docs/network/guides/become-validator.rst
@@ -2,7 +2,7 @@
 .. _node-dashboard: http://localhost:8099
 .. _Discord: https://discord.com/invite/xWmQ5tp
 
-.. _become-a-baker:
+.. _become-a-validator:
 
 =====================================
 Validation with the Concordium Client

--- a/source/mainnet/docs/network/guides/validation-with-wallets.rst
+++ b/source/mainnet/docs/network/guides/validation-with-wallets.rst
@@ -100,7 +100,7 @@ For information about how to update your validator or stop validation, see :ref:
 Validation with ``Concordium-client``
 -------------------------------------
 
-For information about configuring and managing validation in ``Concordium-client``, see :ref:`Validation with the Concordium Client<become-a-baker>`.
+For information about configuring and managing validation in ``Concordium-client``, see :ref:`Validation with the Concordium Client<become-a-validator>`.
 
 Next steps
 ==========

--- a/source/mainnet/docs/network/nodes/run-node-docker/advanced-node-configuration-on-docker.rst
+++ b/source/mainnet/docs/network/nodes/run-node-docker/advanced-node-configuration-on-docker.rst
@@ -16,7 +16,7 @@ router, then you will probably only be able to connect to other nodes,
 but other nodes will not be able to initiate connections to your node.
 This is perfectly fine, and your node will fully participate in the
 Concordium network. It will be able to send transactions and,
-:ref:`if so configured<become-a-baker>`, to produce blocks.
+:ref:`if so configured<become-a-validator>`, to produce blocks.
 
 However you can also make your node an even better network participant by
 enabling inbound connections. The sample configuration makes the node

--- a/source/mainnet/docs/network/nodes/run-node-macos/advanced-node-configuration-on-macos.rst
+++ b/source/mainnet/docs/network/nodes/run-node-macos/advanced-node-configuration-on-macos.rst
@@ -43,7 +43,7 @@ router, then you will probably only be able to connect to other nodes,
 but other nodes will not be able to initiate connections to your node.
 This is perfectly fine, and your node will fully participate in the
 Concordium network. It will be able to send transactions and,
-:ref:`if so configured<become-a-baker>`, to produce blocks.
+:ref:`if so configured<become-a-validator>`, to produce blocks.
 
 However you can also make your node an even better network participant
 by enabling inbound connections. By default, ``concordium-node`` listens

--- a/source/mainnet/docs/network/nodes/run-node-windows/advanced-node-configuration-on-windows.rst
+++ b/source/mainnet/docs/network/nodes/run-node-windows/advanced-node-configuration-on-windows.rst
@@ -38,7 +38,7 @@ The node runs as a background service with no user interface. To verify that itâ
 Enable inbound connections
 ==========================
 
-If you are running your node behind a firewall, or behind your home router, then you will probably only be able to connect to other nodes, but other nodes will not be able to initiate connections to your node. This is perfectly fine, and your node will fully participate in the Concordium network. It will be able to send transactions and, :ref:`if so configured<become-a-baker>`, to produce blocks.
+If you are running your node behind a firewall, or behind your home router, then you will probably only be able to connect to other nodes, but other nodes will not be able to initiate connections to your node. This is perfectly fine, and your node will fully participate in the Concordium network. It will be able to send transactions and, :ref:`if so configured<become-a-validator>`, to produce blocks.
 
 However you can also make your node an even better network participant by enabling inbound connections. By default, ``concordium-node`` listens on port ``8888`` for inbound connections on **Mainnet** and on port ``8889`` for inbound connections on **Testnet**. Depending on your network and platform configuration you will either need to forward an external port to ``8888`` or ``8889`` on your router, open it in your firewall, or both. The details of how this is done will depend on your configuration. See :ref:`Concordium Windows node runner service configuration<node-runner-service-configuration>` for more information.
 

--- a/source/mainnet/docs/protocol/transaction-fees.rst
+++ b/source/mainnet/docs/protocol/transaction-fees.rst
@@ -12,6 +12,8 @@ Stable transaction costs
 
 Concordium combines the freely fluctuating value of the CCD with a transaction cost that remains stable versus EUR. This is achieved by fixing the price of a transaction in EUR, then multiplying this by the current CCD/EUR price. So if the value of the CCD goes up, a user needs fewer CCD to pay for transactions, thereby maintaining a stable cost in EUR terms. The technical implementation of the above principle is described in the following.
 
+.. _computing-transaction-costs:
+
 Computing transaction costs
 ===========================
 

--- a/source/mainnet/tools/index.rst
+++ b/source/mainnet/tools/index.rst
@@ -5,7 +5,7 @@
 Tools
 =====
 
-Welcome to the tools section where you'll find everythin you need to build on the Concordium blockchain.
+Welcome to the tools section where you'll find everything you need to build on the Concordium blockchain.
 
 
 Developer Resources

--- a/source/mainnet/tools/transactions.rst
+++ b/source/mainnet/tools/transactions.rst
@@ -34,51 +34,51 @@ Transaction commands
 ====================
 
 
-+-------------------------------------+------------------------------------------------+
-| Command                             | Description                                    |
-+=====================================+================================================+
-| ``transaction send``                | Transfer CCD tokens                            |
-+-------------------------------------+------------------------------------------------+
-| ``transaction send-scheduled``      | Make a transfer that will be released          |
-|                                     | gradually                                      |
-+-------------------------------------+------------------------------------------------+
-| ``validator add``                   | Add a new validator. For more information, see |
-|                                     | :ref:`become-a-baker`.                         |
-+-------------------------------------+------------------------------------------------+
-| ``validator remove``                | Remove a validator. For more information, see  |
-|                                     | :ref:`become-a-baker`.                         |
-+-------------------------------------+------------------------------------------------+
-| ``validator update-stake``          | Update the staked amount of a validator. For   |
-|                                     | more information, see :ref:`become-a-baker`.   |
-+-------------------------------------+------------------------------------------------+
-| ``validator update-restake``        | Update the restaking switch of a validator. For|
-|                                     | more information, see :ref:`become-a-baker`.   |
-+-------------------------------------+------------------------------------------------+
-| ``validator set-key``               | Update the keys of a validator. For more       |
-|                                     | information, see :ref:`become-a-baker`.        |
-+-------------------------------------+------------------------------------------------+
-| ``account update-keys``             | Update credentials keys for a specific         |
-|                                     | credential                                     |
-+-------------------------------------+------------------------------------------------+
-| ``account unshield``                | Transfer part of the shielded balance to the   |
-|                                     | public balance                                 |
-+-------------------------------------+------------------------------------------------+
-| ``account show``                    | Show account information.                      |
-|                                     | :ref:`See below for specific                   |
-|                                     | information<account-commands>`.                |
-+-------------------------------------+------------------------------------------------+
-| ``identity show``                   | Show identity information.                     |
-|                                     | :ref:`See below for specific                   |
-|                                     | information<identity-commands>`.               |
-+-------------------------------------+------------------------------------------------+
-| ``delegator configure``             | Add, configure, and remove                     |
-|                                     | delegation. :ref:`See below for                |
-|                                     | information<delegation-commands>`.             |
-+-------------------------------------+------------------------------------------------+
-| ``consensus show-chain-parameters`` | Show chain parameters.                         |
-|                                     | :ref:`See below for specific                   |
-|                                     | information<consensus show-chain-parameters>`. |
-+-------------------------------------+------------------------------------------------+
++-------------------------------------+-------------------------------------------------+
+| Command                             | Description                                     |
++=====================================+=================================================+
+| ``transaction send``                | Transfer CCD tokens                             |
++-------------------------------------+-------------------------------------------------+
+| ``transaction send-scheduled``      | Make a transfer that will be released           |
+|                                     | gradually                                       |
++-------------------------------------+-------------------------------------------------+
+| ``validator add``                   | Add a new validator. For more information, see  |
+|                                     | :ref:`become-a-validator`.                      |
++-------------------------------------+-------------------------------------------------+
+| ``validator remove``                | Remove a validator. For more information, see   |
+|                                     | :ref:`become-a-validator`.                      |
++-------------------------------------+-------------------------------------------------+
+| ``validator update-stake``          | Update the staked amount of a validator. For    |
+|                                     | more information, see :ref:`become-a-validator`.|
++-------------------------------------+-------------------------------------------------+
+| ``validator update-restake``        | Update the restaking switch of a validator. For |
+|                                     | more information, see :ref:`become-a-validator`.|
++-------------------------------------+-------------------------------------------------+
+| ``validator set-key``               | Update the keys of a validator. For more        |
+|                                     | information, see :ref:`become-a-validator`.     |
++-------------------------------------+-------------------------------------------------+
+| ``account update-keys``             | Update credentials keys for a specific          |
+|                                     | credential                                      |
++-------------------------------------+-------------------------------------------------+
+| ``account unshield``                | Transfer part of the shielded balance to the    |
+|                                     | public balance                                  |
++-------------------------------------+-------------------------------------------------+
+| ``account show``                    | Show account information.                       |
+|                                     | :ref:`See below for specific                    |
+|                                     | information<account-commands>`.                 |
++-------------------------------------+-------------------------------------------------+
+| ``identity show``                   | Show identity information.                      |
+|                                     | :ref:`See below for specific                    |
+|                                     | information<identity-commands>`.                |
++-------------------------------------+-------------------------------------------------+
+| ``delegator configure``             | Add, configure, and remove                      |
+|                                     | delegation. :ref:`See below for                 |
+|                                     | information<delegation-commands>`.              |
++-------------------------------------+-------------------------------------------------+
+| ``consensus show-chain-parameters`` | Show chain parameters.                          |
+|                                     | :ref:`See below for specific                    |
+|                                     | information<consensus show-chain-parameters>`.  |
++-------------------------------------+-------------------------------------------------+
 
 Each of these commands have a number of parameters specific to them, but share a common set of flags and configuration to control how they build transactions.
 
@@ -197,7 +197,7 @@ Commands for transferring CCD
 The commands for transferring CCD
 are described in the following table.
 
-The add, remove, and configure validators commands are described in the topic :ref:`becoming a validator using the Concordium Client<become-a-baker>`.
+The add, remove, and configure validators commands are described in the topic :ref:`becoming a validator using the Concordium Client<become-a-validator>`.
 
 .. note::
 

--- a/source/mainnet/tools/transactions.rst
+++ b/source/mainnet/tools/transactions.rst
@@ -26,7 +26,7 @@ You can perform all types of transactions with the :ref:`concordium-client<conco
 
 .. Note::
 
-   All transfers and transactions cost a fee. The fee is based on the set NRG for that transaction and the current exchange rate.
+   All transfers and transactions cost a fee. The fee is based on the set :ref:`NRG <computing-transaction-costs>` for that transaction and the current exchange rate.
    The cost of transaction fees is stable in Euros, and therefore the price in CCD varies depending on the CCD to EUR exchange rate. The fee will always be deducted from the **Balance** of the account, so it is important to have some available CCDs to cover fees.
    You can see the fee in the transaction log.
 

--- a/source/mainnet/tools/transactions.rst
+++ b/source/mainnet/tools/transactions.rst
@@ -129,7 +129,7 @@ Account sequence number
 Each account on the Concordium blockchain has a :term:`sequence number<transaction sequence number>` and each
 transaction signed by the account must have a sequence number. For a transaction
 to be considered valid its sequence number must be the next available one for
-the account. The sequence number is maintained by all the bakers in order to
+the account. The sequence number is maintained by all the validators in order to
 validate transactions.
 
 The sequence number can be looked up from an up to date node by running
@@ -197,7 +197,7 @@ Commands for transferring CCD
 The commands for transferring CCD
 are described in the following table.
 
-The add, remove, and configure bakers commands are described in the topic :ref:`becoming a baker using the Concordium Client<become-a-baker>`.
+The add, remove, and configure validators commands are described in the topic :ref:`becoming a validator using the Concordium Client<become-a-baker>`.
 
 .. note::
 
@@ -251,7 +251,7 @@ sender account A has three transaction signing keys 0, 1, and 3.
    Enter password for signing key with index 0: ...
    Enter password for signing key with index 1: ...
    Enter password for signing key with index 3: ...
-   Transaction '7c484aecbc9dce654956cae1a6f9315679f62afe091d74f865f3602bc8003fbd' sent to the baker.
+   Transaction '7c484aecbc9dce654956cae1a6f9315679f62afe091d74f865f3602bc8003fbd' sent to the validator.
    Waiting for the transaction to be committed and finalized.
    You may skip this step by interrupting the command using Ctrl-C (pass flag '--no-wait' to do this by default).
    The transaction will still get processed and may be queried using
@@ -302,7 +302,7 @@ additional flag ``--index.`` If given, this flag is used to select which
    Confirm [yN]: y
    Enter password for signing key with index 0: ...
    Enter password for signing key with index 1: ...
-   Transaction 'b240ed919767b89a03984e71a0c39cff52f3374ab2b1721e489c02dc3fb1e691' sent to the baker.
+   Transaction 'b240ed919767b89a03984e71a0c39cff52f3374ab2b1721e489c02dc3fb1e691' sent to the validator.
    Waiting for the transaction to be committed and finalized.
    You may skip this step by interrupting the command using Ctrl-C (pass flag '--no-wait' to do this by default).
    The transaction will still get processed and may be queried using
@@ -504,13 +504,13 @@ The output is:
      - The amount of time the pool owner needs to wait before changes are effective when either decreasing stake or removing the pool. Note that changes are effective on the first pay day after the cool-down period has expired.
    * -
      - allowed range for finalization commission
-     - The allowed range of finalization commissions bakers may select when creating or updating pools.
+     - The allowed range of finalization commissions validators may select when creating or updating pools.
    * -
      - allowed range for block commission
      - The allowed range of block commissions validators may select when creating or updating pools.
    * -
      - allowed range for transaction commission
-     - The allowed range of transaction commissions bakers may select when creating or updating pools.
+     - The allowed range of transaction commissions validators may select when creating or updating pools.
    * - Passive delegation parameters
      - finalization commission
      - The percentage of finalization rewards retained by the passive delegation, i.e., not given out to delegators.


### PR DESCRIPTION
## Purpose

Fix the below issues based on documentation feedback [[DEV-333: Fix minor terminology issues in documentation](https://linear.app/concordium/issue/DEV-333/fix-minor-terminology-issues-in-documentation):

## Changes

- Fixed typo in Tools section (Index,rst)
- Replaced outdated "baker" terminology with "validator" in Concordium Client transactions page 
- Updated filename become-baker,rst to become-validator.rst and updated related links
- Updated conf.py
- Added link to Transactions fee page from Concordium Client transactions page 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf
