### PR TITLE
Update term IDA to PG in docs

### DIFF
--- a/source/mainnet/docs/guides/multi-credentials.rst
+++ b/source/mainnet/docs/guides/multi-credentials.rst
@@ -81,7 +81,7 @@ Option 2: Generate and sign the transaction on the LEDGER device
 
 #. The LEDGER device says **Signature threshold** which is the number of signatures that’s currently required to make transactions with the account. Navigate to the right and verify that the following information is correct, and then press both buttons.
 
-   -  *AR threshold*: this is the number of identity disclosure authorities required to disclose an identity on the account.
+   -  *AR threshold*: this is the number of Privacy Guardians required to disclose an identity on the account.
 
    -  *Cred. sig. threshold*: this is the number of signatures required to sign transactions on the account.
 

--- a/source/mainnet/docs/guides/overview-shared-accounts.rst
+++ b/source/mainnet/docs/guides/overview-shared-accounts.rst
@@ -10,7 +10,7 @@ In the Desktop Wallet, you have the option of creating shared accounts, also kno
 Credentials
 ===========
 
-It’s the :term:`credentials<credential>` on an account that determine who’s allowed to sign transactions. An account credential holds signature verification keys, information related to the :term:`identity disclosure authority<identity disclosure authority>`, and the public :term:`attributes` of the account owner. The credential proves that the account owner has been verified by an :term:`identity provider`, but it doesn’t identify the account owner to the identity provider. However, in the case of a valid request from a government authority via established legal channels, it allows the identity disclosure authorities and the identity provider, when they work together, to link the account to the users. For more information, see :ref:`Identity framework on Concordium <reference-identity>`.
+It’s the :term:`credentials<credential>` on an account that determine who’s allowed to sign transactions. An account credential holds signature verification keys, information related to the :term:`Privacy Guardians<Privacy Guardian (PG)>`, and the public :term:`attributes` of the account owner. The credential proves that the account owner has been verified by an :term:`identity provider`, but it doesn’t identify the account owner to the identity provider. However, in the case of a valid request from a government authority via established legal channels, it allows the Privacy Guardians and the identity provider, when they work together, to link the account to the users. For more information, see :ref:`Identity framework on Concordium <reference-identity>`.
 
 Signature threshold
 ===================

--- a/source/mainnet/docs/network/guides/run-local-chain.rst
+++ b/source/mainnet/docs/network/guides/run-local-chain.rst
@@ -9,7 +9,7 @@ Run a local chain
 
     Running your own local chain is an advanced process and not applicable for all use cases. Users with little or no blockchain experience should not attempt to run a local chain. If you run into issues while installing, configuring, and running your local chain, contact `Concordium support <http://support.concordium.software>`_.
 
-This guide details how to run your own instance of the Concordium blockchain. This is useful when developing and testing smart contracts. Running your own chain also lets you control various aspects, such as the genesis parameters, identity disclosure authorities, identity providers, and foundation accounts.
+This guide details how to run your own instance of the Concordium blockchain. This is useful when developing and testing smart contracts. Running your own chain also lets you control various aspects, such as the genesis parameters, :term:`Privacy Guardians<Privacy Guardian (PG)>`, identity providers, and foundation accounts.
 
 The chain is run by a network of validator nodes that produce blocks. In the following minimal example you will set up a network comprised of a single validator node that runs *locally* on your system and *does not connect to mainnet or testnet*. Note, however, that the concepts demonstrated here equally apply to any number of validator nodes configured in a LAN or WAN setting.
 
@@ -71,7 +71,7 @@ The ``genesis-creator`` tool uses a TOML configuration file format for specifyin
 
 * the initial protocol version
 * cryptographic parameters
-* anonymity revokers (Identity disclosure authorities)
+* anonymity revokers (:term:`Privacy Guardians<Privacy Guardian (PG)>`)
 * identity providers
 * foundation accounts
 * keys for updating the chain

--- a/source/mainnet/docs/network/web3-id/index.rst
+++ b/source/mainnet/docs/network/web3-id/index.rst
@@ -9,7 +9,7 @@
 Identity on Concordium
 ======================
 
-Concordium’s identity layer is built into the protocol. Every account on the chain has one or more credentials issued by specially sanctioned identity providers who are expected to be able to provide full disclosure of the identity (in concert with the identity disclosure authorities). ID 2.0 made it possible to use these identities off-chain: wallets allow using identities to prove properties about the holder, such as their nationality or age. These are known as :term:`account credentials<account credential>`.
+Concordium’s identity layer is built into the protocol. Every account on the chain has one or more credentials issued by specially sanctioned identity providers who are expected to be able to provide full disclosure of the identity in concert with the :term:`Privacy Guardians<Privacy Guardian (PG)>`. ID 2.0 made it possible to use these identities off-chain: wallets allow using identities to prove properties about the holder, such as their nationality or age. These are known as :term:`account credentials<account credential>`.
 
 .. image:: ../../../docs/images/mobile-wallet/MW12.png
    :width: 25%

--- a/source/mainnet/docs/protocol/manage-accounts.rst
+++ b/source/mainnet/docs/protocol/manage-accounts.rst
@@ -56,7 +56,7 @@ account, the initial account, on behalf of the user. At the end of the identity 
 additional accounts and the user gets access to the initial account on the Concordium Platform. These certificates are valid for a given period. You can obtain a new certificate
 by creating a new identity and going through the identity verification process again with an identity provider.
 
-Based on the user identity certificate the user can subsequently create other accounts (see below) that can only be linked to the user if the identity disclosure authorities and the identity provider are
+Based on the user identity certificate the user can subsequently create other accounts (see below) that can only be linked to the user if the :term:`Privacy Guardians<Privacy Guardian (PG)>` and the identity provider are
 involved. This gives a user a way to create accounts with an additional layer of privacy protection compared to that in the initial account. The owner of a regular account is not known to the identity providers or any other single entity. To facilitate compliance with relevant regulations, a regular account can only be created from an *identity* which is issued :term:`off-chain` by an Identity provider. While an account has to be created from an identity, the user's privacy is still protected, and the account owner's identity can only be revealed via the process of :ref:`disclosing an identity<reference-identity-disclosure-processes>`, which can only happen under stringent regulations. In particular, a key feature of the design of identities and accounts is that the identity provider cannot reveal the identity of an account on their own.
 
 Account creation
@@ -84,7 +84,7 @@ identity to create accounts.
 
 Every account on the chain must be derived from an identity that is verified and
 signed by an approved identity provider. It is publicly visible which identity
-provider issued an identity for an account and who the identity disclosure authority are
+provider issued an identity for an account and who the :term:`Privacy Guardians<Privacy Guardian (PG)>` are
 for the account and the identity. This means that anybody can check it
 before interacting with an account to judge the level of risk in the transaction.
 

--- a/source/mainnet/docs/resources/glossary.rst
+++ b/source/mainnet/docs/resources/glossary.rst
@@ -13,7 +13,7 @@ Also see the Concordium `Whitepaper <https://developer.concordium.software/gover
 
    Account
 
-      An addressable store of funds on the blockchain. An account is associated with one or more *account keys* that can be used to authorize transactions originating from the account, as well as with an :term:`encryption key`. An account is also associated with the account holder's :term:`identity`, although this association is encrypted. This identity can only be disclosed by :term:`identity disclosure authorities<identity disclosure authority>`, in cooperation with the account's :term:`identity provider`.
+      An addressable store of funds on the blockchain. An account is associated with one or more *account keys* that can be used to authorize transactions originating from the account, as well as with an :term:`encryption key`. An account is also associated with the account holder's :term:`identity`, although this association is encrypted. This identity can only be disclosed by :term:`Privacy Guardians<Privacy Guardian (PG)>`, in cooperation with the account's :term:`identity provider`.
 
    Account credential
 
@@ -31,10 +31,6 @@ Also see the Concordium `Whitepaper <https://developer.concordium.software/gover
    Alias
 
       A kind of sub-account structure that can be created. An account owner can create different aliases for different uses to keep track of transfers and assign them meaning. Each account has 16777216 addresses, namely a so-called canonical account address together with matching account aliases. The canonical account address is derived when an account is created on chain. The other 16 million addresses with matching initial 29 bytes are referred to as account aliases for the same account. Thus, accounts can be referred to by any address whose initial 29 bytes match.
-
-   Identity disclosure authority
-
-      An authority who has power to know the identity of a participant. The identity disclosure authority and :term:`identity provider` can work together to determine the owner of an account and determine which accounts belong to the same owner. (They should only do so when legally obliged to, such as by a court order.) Identity disclosure is a two-stage process, requiring cooperation of multiple parties.
 
    Approval voting
 
@@ -260,7 +256,7 @@ Also see the Concordium `Whitepaper <https://developer.concordium.software/gover
 
    Initial Account
 
-      An intial account is an account submitted to the chain by the identity provider during the process of requesting a new identity. The initial account can perform all of the same actions as a regular account, however the real-life identity of the initial-account owner is known by the identity provider who submitted it to the chain. In contrast, the real-life identity of the owner of a regular account can only be ascertained by the identity disclosure authority working in concert with the identity provider.
+      An intial account is an account submitted to the chain by the identity provider during the process of requesting a new identity. The initial account can perform all of the same actions as a regular account, however the real-life identity of the initial-account owner is known by the identity provider who submitted it to the chain. In contrast, the real-life identity of the owner of a regular account can only be ascertained by the :term:`Privacy Guardians<Privacy Guardian (PG)>` in concert with the identity provider.
 
       Initial accounts are only relevant for Desktop Wallet.
 
@@ -364,7 +360,7 @@ Also see the Concordium `Whitepaper <https://developer.concordium.software/gover
 
    Qualified authority
 
-      A governmental body that has the authority to act in a relevant jurisdiction. For example, a local police force, a local court or an investigatory division of a local authority that regulates financial conduct may have authority to act in their relevant jurisdictions. These authorities are qualified to begin the process of disclosing the identity of a user when they proceed through established legal channels and make a formal request. The outcome of such a request is likely to be that a qualified authority obtains an official order, which may be in the form of a warrant, court order, or similar instrument. Only after a qualified authority validly serves an official order upon the relevant :term:`identity disclosure authorities<identity disclosure authority>` and :term:`identity provider`, can the real-world identity of a user be revealed and only to the extent set out in the order.
+      A governmental body that has the authority to act in a relevant jurisdiction. For example, a local police force, a local court or an investigatory division of a local authority that regulates financial conduct may have authority to act in their relevant jurisdictions. These authorities are qualified to begin the process of disclosing the identity of a user when they proceed through established legal channels and make a formal request. The outcome of such a request is likely to be that a qualified authority obtains an official order, which may be in the form of a warrant, court order, or similar instrument. Only after a qualified authority validly serves an official order upon the relevant :term:`Privacy Guardians<Privacy Guardian (PG)>` and :term:`identity provider`, can the real-world identity of a user be revealed and only to the extent set out in the order.
 
    Quorum certificate
 

--- a/source/mainnet/tools/query-node.rst
+++ b/source/mainnet/tools/query-node.rst
@@ -273,7 +273,7 @@ ID layer
 
    $concordium-client identity show (identity-providers|anonymity-revokers) [--block BLOCK]
 
-Display the list of identity providers or identity disclosure authorities at a given block,
+Display the list of identity providers or :term:`Privacy Guardians<Privacy Guardian (PG)>` at a given block,
 defaulting to the :term:`best block`.
 
 .. _exchange-rates:

--- a/source/mainnet/tools/transactions.rst
+++ b/source/mainnet/tools/transactions.rst
@@ -185,7 +185,7 @@ To show the identity providers authorized by Concordium and a URL, enter:
 
    $concordium-client identity show identity-providers
 
-To show the identity disclosure authorities, enter:
+To show the Privacy Guardians, enter:
 
 .. code-block:: console
 


### PR DESCRIPTION
Update term IDA to PG in docs

## Purpose
Replace the term Identity Disclosure Authority with new term Privacy Guardian in docs. [DEV-327: Update IDA to PG (Privacy Guardians) in documentation](https://linear.app/concordium/issue/DEV-327/update-ida-to-pg-privacy-guardians-in-documentation)

## Changes

Updated Glossary and all affected pages.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

