### PR TITLE
Governance ledger app/update installation steps

### DIFF
--- a/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
+++ b/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
@@ -2,11 +2,15 @@
 
 .. include:: ../../variables.rst
 
+.. |nano-s-firmware| replace:: **2.1.0**
+.. |nano-s-plus-firmware| replace:: **1.4.0**
+.. |ccd-governance-version| replace:: **1.2.0**
+
 .. _install-Ledger-app:
 
-==============================================================
-Set up the LEDGER device and install the Concordium LEDGER App
-==============================================================
+=========================================================================
+Set up the LEDGER device and install the Concordium Governance LEDGER App
+=========================================================================
 
 .. warning::
 
@@ -48,45 +52,51 @@ The LEDGER device will generate the unique 24-word recovery phrase that is used 
 
    Make sure that you write down the recovery phrase precisely as displayed and in the correct order. The recovery phrase is the only backup of your private keys.
 
-Once you've set up the LEDGER device, you must check that it's running the proper firmware version for your device. The Concordium LEDGER App currently supports LEDGER firmware version 1.0.3 for LEDGER NANO S PLUS.
+
+.. tabs::
+
+   .. group-tab:: Nano S
+
+       Once you've set up the LEDGER device, you must check that it's running the proper firmware version for your device. The Concordium LEDGER App currently supports LEDGER firmware version |nano-s-firmware| for LEDGER NANO S.
+
+   .. group-tab:: Nano S+
+
+       Once you've set up the LEDGER device, you must check that it's running the proper firmware version for your device. The Concordium LEDGER App currently supports LEDGER firmware version |nano-s-plus-firmware| for LEDGER NANO S+.
 
 Update the LEDGER device firmware
 ---------------------------------
 
 To update the LEDGER device firmware, do the following:
 
-#. On the LEDGER device press both buttons for a little while until the Settings icon appears. Press both buttons to enter the Settings menu.
+.. tabs::
 
-#. Press both buttons on the **General** menu item.
+   .. group-tab:: Nano S
 
-#. Press the right button to navigate to **Firmware version**.
+      #. On the LEDGER device press both buttons for a little while until the Settings icon appears. Press both buttons to enter the Settings menu.
 
-#. Press both buttons to view the **Secure Element** version.
+      #. Press both buttons on the **General** menu item.
 
-   - I it says **1.1.0**, you don't have to update the firmware. If there's a lower version number, you'll have to update the firmware.
+      #. Press the right button to navigate to **Firmware version**.
 
-For details on how to update the LEDGER firmware, see `LEDGER NANO S PLUS guide <https://support.ledger.com/hc/en-us/articles/4445777839901-Update-Ledger-Nano-S-Plus-firmware?docs=true>`_.
+      #. Press both buttons to view the **Secure Element** version.
 
-.. _Ledger-downloads:
+          - If it says |nano-s-firmware|, you don't have to update the firmware. If there's a lower version number, you'll have to update the firmware.
 
-Ledger packages
----------------
+      For details on how to update the LEDGER firmware, see `LEDGER NANO S guide <https://support.ledger.com/hc/en-us/articles/4445777839901-Update-Ledger-Nano-S-Plus-firmware?docs=true>`_.
 
-Once you have updated the firmware version, you can download the LEDGER app:
+   .. group-tab:: Nano S+
 
-`Dwnload the Concordium LEDGER App 1.1.0 for LEDGER firmware version 1.1.0 <https://s3.eu-west-1.amazonaws.com/distribution.mainnet.concordium.software/tools/concordium-governance-ledger-app-1.1.0-nanos-plus-.zip>`_
+      #. On the LEDGER device press both buttons for a little while until the Settings icon appears. Press both buttons to enter the Settings menu.
 
-When installing the certificate, ensure that the public key of the certificate is :substitution-code:`|ledger-app-public-key|`.
+      #. Press both buttons on the **General** menu item.
 
-Follow the instructions below to update your app:
+      #. Press the right button to navigate to **Firmware version**.
 
-   * :ref:`update-app-windows`
-   * :ref:`update-app-macos`
-   * :ref:`update-app-ubuntu`
+      #. Press both buttons to view the **Secure Element** version.
 
-It should not be necessary to update the certificate.
+          - If it says |nano-s-plus-firmware|, you don't have to update the firmware. If there's a lower version number, you'll have to update the firmware.
 
-See the changelog(link) for this governance version of the app.
+      For details on how to update the LEDGER firmware, see `LEDGER NANO S PLUS guide <https://support.ledger.com/hc/en-us/articles/4445777839901-Update-Ledger-Nano-S-Plus-firmware?docs=true>`_.
 
 Install Python and pip
 =====================
@@ -103,9 +113,9 @@ You need to install Python and pip to proceed with installing the Concordium LED
 
       #. In **Search**, in the upper right corner, enter *python*.
 
-      #. Select **Python 3.9**, and then select **Install**.
+      #. Select **Python 3**, and then select **Install**.
 
-         Python is downloaded and installed automatically. Depending on the setup of your computer, you might see a message saying **Python 3.9 just got installed**.
+         Python is downloaded and installed automatically. Depending on the setup of your computer, you might see a message saying **Python 3 just got installed**.
 
       Restart your computer, and then confirm that Python and Pip were installed.
 
@@ -129,9 +139,7 @@ You need to install Python and pip to proceed with installing the Concordium LED
 
       #. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
 
-      #. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``.
-
-      #. Install the package manager `Homebrew <https://brew.sh/>`_; you will need the Homebrew tool to install the remaining dependencies. Copy the following line into the Terminal and press enter.
+      #. Install the package manager `Homebrew <https://brew.sh/>`_ (if not already available on your mac); you will need the Homebrew tool to install the remaining dependencies. Copy the following line into the Terminal and press enter.
 
          .. code-block:: console
 
@@ -141,7 +149,7 @@ You need to install Python and pip to proceed with installing the Concordium LED
 
          .. code-block:: console
 
-            $brew install python@3.9 libusb libjpeg
+            $brew install python@3 libusb libjpeg
 
          You can use `pyenv<https://github.com/pyenv/pyenv>` if you need multiple python versions. Installing libjpeg is only necessary if you have a Mac with an M1 or similar Apple Silicon CPU.
 
@@ -186,10 +194,36 @@ You need to install Python and pip to proceed with installing the Concordium LED
 
             $sudo pip3 install ledgerblue
 
-Install the custom certificate
-=============================
+.. _Ledger-downloads:
 
-You need to install a custom certificate to ensure that the LEDGER device trusts applications signed by Concordium's private key. The steps vary by operating system.
+Download Concordium Governance LEDGER app
+=========================================
+
+Once you have updated the firmware version, you can download the LEDGER app:
+
+.. tabs::
+
+   .. group-tab:: Nano S
+
+      #. `Download the Concordium Governance LEDGER App for LEDGER <https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.2.0/concordium-governance-ledger-app-1.2.0-nanos-2.1.0.zip>`_
+
+      #. Extract the files from the ``.zip`` folder to a folder on your computer.
+      
+
+   .. group-tab:: Nano S+
+
+      #. `Download the Concordium Governance LEDGER App for LEDGER <https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.2.0/concordium-governance-ledger-app-1.2.0-nanosplus.zip>`_
+
+      #. Extract the files from the ``.zip`` folder to a folder on your computer.
+
+Install the custom certificate (Nano S only)
+============================================
+
+.. Note::
+
+   If the certificate is already installed on the device, it should not be necessary to update this. If you're a LEDGER Nano S+ user, you can also skip this section.
+
+You need to install a custom certificate to ensure that the LEDGER device trusts applications signed by Concordium's private key.
 
 .. tabs::
 
@@ -198,10 +232,6 @@ You need to install a custom certificate to ensure that the LEDGER device trusts
       #. Close all applications that might be connected to the LEDGER device such as LEDGER LIVE and Concordium Desktop Wallet and keep them closed until you've completed the steps in this guide.
 
       #. Disconnect the LEDGER device from your computer.
-
-      #. :ref:`Download the ZIP folder with Concordium LEDGER application<Ledger-downloads>`.
-
-      #. Extract the files from the ZIP folder to a folder on your computer.
 
       #. Now you need to start recovery mode on the LEDGER device.
 
@@ -217,17 +247,13 @@ You need to install a custom certificate to ensure that the LEDGER device trusts
 
          - :substitution-code:`|ledger-app-public-key|`
 
-      and then press both buttons when the LEDGER device says **Trust certificate**.
+      #. Press both buttons when the LEDGER device says **Trust certificate**.
 
       #. Enter your PIN. The certificate has now been installed on the LEDGER device.
 
    .. group-tab:: macOS
 
       #. Close all applications that might be connected to the LEDGER device such as LEDGER LIVE and Concordium Desktop Wallet and keep them closed until you've completed the steps in this guide.
-
-      #. :ref:`Download the ZIP folder with the Concordium LEDGER application<Ledger-downloads>`.
-
-      #. Extract the files from the ZIP folder to a folder on your computer.
 
       #. Disconnect the LEDGER device from your computer.
 
@@ -239,7 +265,23 @@ You need to install a custom certificate to ensure that the LEDGER device trusts
 
       #. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
 
-      #. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``.
+      #. Navigate to where you have downloaded and extracted the LEDGER install package. For example to navigate to the default download directory in a Terminal, enter 
+
+         .. tabs::
+            
+            .. group-tab:: Nano S
+
+               .. code-block:: console
+                  :substitutions:
+
+                  $cd ~/Downloads/concordium-governance-ledger-app-|ccd-governance-version|-nanos-|nano-s-firmware|
+
+            .. group-tab:: Nano S+
+
+               .. code-block:: console
+                  :substitutions:
+
+                  $cd ~/Downloads/concordium-governance-ledger-app-|ccd-governance-version|-nanosplus
 
       #. Load the certificate onto the LEDGER device by running the following script from the extracted folder:
 
@@ -253,17 +295,13 @@ You need to install a custom certificate to ensure that the LEDGER device trusts
 
          - :substitution-code:`|ledger-app-public-key|`
 
-      and then press both buttons when the LEDGER device says **Trust certificate**.
+      #. Press both buttons when the LEDGER device says **Trust certificate**.
 
       #. Enter your PIN. The certificate has now been installed on the LEDGER device.
 
    .. group-tab:: Ubuntu
 
       #. Close all applications that might be connected to the LEDGER device such as LEDGER LIVE and Concordium Desktop Wallet and keep them closed until you've completed the steps in this guide.
-
-      #. Download the ZIP folder with the Concordium LEDGER application.
-
-      #. Extract the files from the ZIP folder to a folder on your computer.
 
       #. Disconnect the LEDGER device from your computer.
 
@@ -285,14 +323,14 @@ You need to install a custom certificate to ensure that the LEDGER device trusts
 
          - :substitution-code:`|ledger-app-public-key|`
 
-      and then press both buttons when the LEDGER device says **Trust certificate**.
+      #. Press both buttons when the LEDGER device says **Trust certificate**.
 
       #. Enter your PIN. The certificate has now been installed on the LEDGER device.
 
-Install the Concordium LEDGER app
-================================
+Install the Concordium Governance LEDGER app
+============================================
 
-After installing the certificate, you can proceed to install the Concordium LEDGER app. The installation steps vary by operating system.
+After installing the certificate, you can proceed to install the Concordium LEDGER app.
 
 .. tabs::
 
@@ -312,7 +350,23 @@ After installing the certificate, you can proceed to install the Concordium LEDG
 
       #. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
 
-      #. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``.
+      #. Navigate to where you have downloaded and extracted the LEDGER install package. For example to navigate to the default download directory in a Terminal, enter 
+
+         .. tabs::
+            
+            .. group-tab:: Nano S
+
+               .. code-block:: console
+                  :substitutions:
+
+                  $cd ~/Downloads/concordium-governance-ledger-app-|ccd-governance-version|-nanos-|nano-s-firmware|
+
+            .. group-tab:: Nano S+
+
+               .. code-block:: console
+                  :substitutions:
+
+                  $cd ~/Downloads/concordium-governance-ledger-app-|ccd-governance-version|-nanosplus
 
       #. Install the Concordium application on the LEDGER device by running the following script from the folder you extracted the files to:
 
@@ -341,7 +395,7 @@ After installing the certificate, you can proceed to install the Concordium LEDG
 Update the Concordium LEDGER app
 ===============================
 
-For the app to work properly with the current version of the Desktop Wallet, make sure that you update to the latest version of the app. The update process varies by operating system.
+For the app to work properly with the current version of the Desktop Wallet, make sure that you update to the latest version of the app.
 
 .. tabs::
 
@@ -379,7 +433,23 @@ For the app to work properly with the current version of the Desktop Wallet, mak
 
       #. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
 
-      #. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-ledger-app-2.0.3-target-2.1.0``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-ledger-app-2.0.3-target-2.1.0``.
+      #. Navigate to where you have downloaded the LEDGER install package. For example to navigate to the default download directory in a Terminal, enter 
+
+         .. tabs::
+            
+            .. group-tab:: Nano S
+
+               .. code-block:: console
+                  :substitutions:
+
+                  $cd ~/Downloads/concordium-governance-ledger-app-|ccd-governance-version|-nanos-|nano-s-firmware|
+
+            .. group-tab:: Nano S+
+
+               .. code-block:: console
+                  :substitutions:
+
+                  $cd ~/Downloads/concordium-governance-ledger-app-|ccd-governance-version|-nanosplus
 
       #. Install the Concordium application on the LEDGER device by running the following script from the folder you extracted the files to:
 
@@ -387,9 +457,9 @@ For the app to work properly with the current version of the Desktop Wallet, mak
 
             $./install.sh
 
-      .. Note::
+         .. Note::
 
-         If you get the error ``loadApp.py: error: unrecognized arguments: --apiLevel 1`` this means that you have an older version of the Python tools for LEDGER (ledgerblue). To update, run ``$pip3 install ledgerblue --upgrade``.
+            If you get the error ``loadApp.py: error: unrecognized arguments: --apiLevel 1`` this means that you have an older version of the Python tools for LEDGER (ledgerblue). To update, run ``$pip3 install ledgerblue --upgrade``.
 
       #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**.
 

--- a/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
+++ b/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
@@ -119,7 +119,7 @@ You need to install Python and pip to proceed with installing the Concordium LED
 
          Python is downloaded and installed automatically. Depending on the setup of your computer, you might see a message saying **Python 3 just got installed**.
 
-      Restart your computer, and then confirm that Python and Pip were installed.
+      #. Restart your computer, and then confirm that Python and Pip were installed.
 
       #. In the **Start** menu, type *PowerShell* and select **Windows PowerShell**. The command-line window opens.
 
@@ -486,9 +486,9 @@ For the app to work properly with the current version of the Desktop Wallet, mak
 
       #. Run the ``install.sh`` file from the folder that you extracted the files to.
 
-      .. Note::
+         .. Note::
 
-         If you get the error ``loadApp.py: error: unrecognized arguments: --apiLevel 1`` this means that you have an older version of the Python tools for LEDGER (ledgerblue). To update, run ``$sudo pip3 install ledgerblue --upgrade``.
+            If you get the error ``loadApp.py: error: unrecognized arguments: --apiLevel 1`` this means that you have an older version of the Python tools for LEDGER (ledgerblue). To update, run ``$sudo pip3 install ledgerblue --upgrade``.
 
       #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**.
 

--- a/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
+++ b/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
@@ -20,7 +20,7 @@ To be able to sign and send transactions using the Desktop Wallet, you need a LE
 
 .. Note::
 
-   The LEDGER NANO X is not supported currently.
+   Only Ledger Nano S/S+ is currently supported.
 
 Prerequisites
 =============
@@ -29,14 +29,14 @@ Prerequisites
 
 .. Warning::
 
-   During the process described in this guide, you’ll generate private keys on the LEDGER device, and you’ll receive a 24-word recovery phrase. This is the only backup of your private keys. Make sure that you store it securely.
+   During the process described in this guide, you'll generate private keys on the LEDGER device, and you'll receive a 24-word recovery phrase. This is the only backup of your private keys. Make sure that you store it securely.
 
 Set up the LEDGER device
 ========================
 
 The LEDGER device will generate the unique 24-word recovery phrase that is used to derive your private keys.
 
-#. Download and install **Ledger Live**. For information on how to do this, see `Ledger's documentation <https://www.ledger.com/ledger-live/download>`_. You’ll only need Ledger Live when you set up the LEDGER device and update the firmware.
+#. Download and install **Ledger Live**. For information on how to do this, see `Ledger's documentation <https://www.ledger.com/ledger-live/download>`_. You'll only need Ledger Live when you set up the LEDGER device and update the firmware.
 
 #. Open **Ledger Live**, select **Get started**, and then select **Ledger device**.
 
@@ -63,7 +63,7 @@ To update the LEDGER device firmware, do the following:
 
 #. Press both buttons to view the **Secure Element** version.
 
-   - I it says **1.1.0**, you don't have to update the firmware. If there’s a lower version number, you’ll have to update the firmware.
+   - I it says **1.1.0**, you don't have to update the firmware. If there's a lower version number, you'll have to update the firmware.
 
 For details on how to update the LEDGER firmware, see `LEDGER NANO S PLUS guide <https://support.ledger.com/hc/en-us/articles/4445777839901-Update-Ledger-Nano-S-Plus-firmware?docs=true>`_.
 
@@ -88,338 +88,332 @@ It should not be necessary to update the certificate.
 
 See the changelog(link) for this governance version of the app.
 
-Install Concordium LEDGER app on Windows
-========================================
+Install Python and pip
+=====================
 
-.. _install-python-pip-windows:
+You need to install Python and pip to proceed with installing the Concordium LEDGER app. The installation steps depend on your operating system.
 
-Install Python3 and pip
------------------------
+.. tabs::
 
-#. In the **Start** menu, type *store* to open the Microsoft store.
+   .. group-tab:: Windows
 
-#. In **Search**, in the upper right corner, enter *python*.
+      .. _install-python-pip-windows:
 
-#. Select **Python 3.9**, and then select **Install**.
+      #. In the **Start** menu, type *store* to open the Microsoft store.
 
-   Python is downloaded and installed automatically. Depending on the setup of your computer, you might see a message saying **Python 3.9 just got installed**.
+      #. In **Search**, in the upper right corner, enter *python*.
 
-Restart your computer, and then confirm that Python and Pip were installed.
+      #. Select **Python 3.9**, and then select **Install**.
 
-#. In the **Start** menu, type *PowerShell* and select **Windows PowerShell**. The command-line window opens.
+         Python is downloaded and installed automatically. Depending on the setup of your computer, you might see a message saying **Python 3.9 just got installed**.
 
-#. To confirm that Python3 was installed, enter
+      Restart your computer, and then confirm that Python and Pip were installed.
 
-   .. code-block:: console
+      #. In the **Start** menu, type *PowerShell* and select **Windows PowerShell**. The command-line window opens.
 
-      $Python3 --version
+      #. To confirm that Python3 was installed, enter
 
-#. To confirm that the package manager named pip is installed, enter
+         .. code-block:: console
 
-   .. code-block:: console
+            $Python3 --version
 
-      $pip --version
+      #. To confirm that the package manager named pip is installed, enter
 
+         .. code-block:: console
 
-Install the custom certificate on Windows
------------------------------------------
+            $pip --version
 
-You now have to install a custom certificate on the LEDGER device to ensure that it trusts applications signed by Concordium's private key.
+   .. group-tab:: macOS
 
-#. Close all applications that might be connected to the LEDGER device such as LEDGER LIVE and Concordium Desktop Wallet and keep them closed until you’ve completed the steps in this guide.
+      .. _install-python-pip-macos:
 
-#. Disconnect the LEDGER device from your computer.
+      #. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
 
-#. :ref:`Download the ZIP folder with Concordium LEDGER application<Ledger-downloads>`.
+      #. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``.
 
-#. Extract the files from the ZIP folder to a folder on your computer.
+      #. Install the package manager `Homebrew <https://brew.sh/>`_; you will need the Homebrew tool to install the remaining dependencies. Copy the following line into the Terminal and press enter.
 
-#. Now you need to start recovery mode on the LEDGER device.
+         .. code-block:: console
 
-   - On the LEDGER device, press the *left* button and hold it down while you reconnect the LEDGER device to the computer. Navigate to **Recovery mode** and press both buttons to enter **recovery mode**.
+            $/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-#. Enter your PIN code.
+      #. To install Python3, Pip3, `libusb <https://libusb.info/>`_, and `libjpeg <http://libjpeg.sourceforge.net/>`_, copy the following into the Terminal and press Enter:
 
-#. Open the folder you extracted the files to and double-click the ``loadcertificate.bat`` file. If there’s a message saying **Windows protected your PC**, select **More info**, and then select **Run anyway**. A command-line window opens.
+         .. code-block:: console
 
-#. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. You can safely ignore the message in the command-line window saying **Broken certificate chain - loading from user key**. This is expected behavior.
+            $brew install python@3.9 libusb libjpeg
 
-#. The LEDGER device says **Certificate concordium**. Press the right button to navigate through the key, while confirming that it is the following:
+         You can use `pyenv<https://github.com/pyenv/pyenv>` if you need multiple python versions. Installing libjpeg is only necessary if you have a Mac with an M1 or similar Apple Silicon CPU.
 
-   - :substitution-code:`|ledger-app-public-key|`
+      #. To install ledgerblue, copy the following into the Terminal and press Enter:
 
-and then press both buttons when the LEDGER device says **Trust certificate**.
+         .. code-block:: console
 
-#. Enter your PIN. The certificate has now been installed on the LEDGER device.
+            $pip3 install ledgerblue
 
-.. _install-ledger-app-windows:
+   .. group-tab:: Ubuntu
 
-Install the Concordium LEDGER app on Windows
---------------------------------------------
+      .. _install-python-pip-ubuntu:
 
-#. In the folder that you extracted the files to, double-click the ``install.bat`` file. If there’s a message saying **Windows protected your PC**, select **More info**, and then select **Run anyway**.
+      #. Add udev rules. For more information, see the Linux section in `LEDGER 's guide Fix connection history <https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues>`_.
 
-#. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. The LEDGER device says **Loading, please wait** while it installs the app.
+         .. code-block:: console
 
-#. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. You can now use the LEDGER device with the Desktop Wallet.
+            $wget -q -O - https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | sudo bash
 
-.. _update-app-windows:
 
-Update the Concordium LEDGER app on Windows
--------------------------------------------
+      2. Install python3:
 
-For the app to work properly with the current version of the Desktop Wallet, make sure that you update to the latest version of the app.
+         .. code-block:: console
 
-.. Note::
-    Before updating, verify that you have :ref:`installed Python3, pip, and the Python tools <install-python-pip-windows>` for LEDGER (ledgerblue) before updating the app.
+            $sudo apt-get install python3
 
-#. :ref:`Download the LEDGER app<Ledger-downloads>` if you haven't done so already.
+      3. Install pip:
 
-#. In the folder that you extracted the files to, double-click the ``install.bat`` file. If there’s a message saying **Windows protected your PC**, select **More info**, and then select **Run anyway**.
+         .. code-block:: console
 
-.. Note::
+            $sudo apt-get install python3-pip
 
-   If you get the error ``loadApp.py: error: unrecognized arguments: --apiLevel 1`` this means that you have an older version of the Python tools for LEDGER (ledgerblue). To update, run ``$pip3 install ledgerblue --upgrade``.
+      4. Install
 
-#. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons.
+         .. code-block:: console
 
-#. Before you can install the new version of the LEDGER app, you have to uninstall the old one. The LEDGER device says **Uninstall Concordium**. Press the right button to navigate through the identifier until the LEDGER device says **Confirm action**. Press both buttons to confirm. The LEDGER device says **Loading, please wait** while it installs the app.
+            $sudo apt-get install libudev-dev libusb-1.0-0-dev python-dev
 
-#. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. Press the left button to verify that you've installed the latest version of the LEDGER app.
+      5. Install ledgerblue:
 
-Install Concordium LEDGER app on macOS
-======================================
+         .. code-block:: console
 
-.. _install-python-pip-macos:
+            $sudo pip3 install ledgerblue
 
-Install Homebrew, Python3, and pip
-----------------------------------
+Install the custom certificate
+=============================
 
-#. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
+You need to install a custom certificate to ensure that the LEDGER device trusts applications signed by Concordium's private key. The steps vary by operating system.
 
-#. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``.
+.. tabs::
 
-#. Install the package manager `Homebrew <https://brew.sh/>`_; you will need the Homebrew tool to install the remaining dependencies. Copy the following line into the Terminal and press enter.
+   .. group-tab:: Windows
 
-   .. code-block:: console
+      #. Close all applications that might be connected to the LEDGER device such as LEDGER LIVE and Concordium Desktop Wallet and keep them closed until you've completed the steps in this guide.
 
-      $/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      #. Disconnect the LEDGER device from your computer.
 
-#. To install Python3, Pip3, `libusb <https://libusb.info/>`_, and `libjpeg <http://libjpeg.sourceforge.net/>`_, copy the following into the Terminal and press Enter:
+      #. :ref:`Download the ZIP folder with Concordium LEDGER application<Ledger-downloads>`.
 
-   .. code-block:: console
+      #. Extract the files from the ZIP folder to a folder on your computer.
 
-      $brew install python@3.9 libusb libjpeg
+      #. Now you need to start recovery mode on the LEDGER device.
 
-   You can use `pyenv<https://github.com/pyenv/pyenv>` if you need multiple python versions. Installing libjpeg is only necessary if you have a Mac with an M1 or similar Apple Silicon CPU.
+         - On the LEDGER device, press the *left* button and hold it down while you reconnect the LEDGER device to the computer. Navigate to **Recovery mode** and press both buttons to enter **recovery mode**.
 
-#. To install ledgerblue, copy the following into the Terminal and press Enter:
+      #. Enter your PIN code.
 
-   .. code-block:: console
+      #. Open the folder you extracted the files to and double-click the ``loadcertificate.bat`` file. If there's a message saying **Windows protected your PC**, select **More info**, and then select **Run anyway**. A command-line window opens.
 
-      $pip3 install ledgerblue
+      #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. You can safely ignore the message in the command-line window saying **Broken certificate chain - loading from user key**. This is expected behavior.
 
-Install the custom certificate using macOS
-------------------------------------------
+      #. The LEDGER device says **Certificate concordium**. Press the right button to navigate through the key, while confirming that it is the following:
 
-You now have to install a custom certificate to ensure that the LEDGER device trusts applications signed by Concordium's private key.
+         - :substitution-code:`|ledger-app-public-key|`
 
-#. Close all applications that might be connected to the LEDGER device such as LEDGER LIVE and Concordium Desktop Wallet and keep them closed until you’ve completed the steps in this guide.
+      and then press both buttons when the LEDGER device says **Trust certificate**.
 
-#. :ref:`Download the ZIP folder with the Concordium LEDGER application<Ledger-downloads>`.
+      #. Enter your PIN. The certificate has now been installed on the LEDGER device.
 
-#. Extract the files from the ZIP folder to a folder on your computer.
+   .. group-tab:: macOS
 
-#. Disconnect the LEDGER device from your computer.
+      #. Close all applications that might be connected to the LEDGER device such as LEDGER LIVE and Concordium Desktop Wallet and keep them closed until you've completed the steps in this guide.
 
-#. Now you need to start recovery mode on the LEDGER device.
+      #. :ref:`Download the ZIP folder with the Concordium LEDGER application<Ledger-downloads>`.
 
-   - On the LEDGER device, press the *left* button and hold it down while you reconnect the LEDGER device to the computer. Navigate to **Recovery mode** and press both buttons to enter **recovery mode**.
+      #. Extract the files from the ZIP folder to a folder on your computer.
 
-#. Enter your PIN code.
+      #. Disconnect the LEDGER device from your computer.
 
-#. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
+      #. Now you need to start recovery mode on the LEDGER device.
 
-#. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``.
+         - On the LEDGER device, press the *left* button and hold it down while you reconnect the LEDGER device to the computer. Navigate to **Recovery mode** and press both buttons to enter **recovery mode**.
 
-#. Load the certificate onto the LEDGER device by running the following script from the extracted folder:
+      #. Enter your PIN code.
 
-   .. code-block:: console
+      #. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
 
-      $./loadcertificate.sh
+      #. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``.
 
-#. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. You can safely ignore the message in the command-line window saying **Broken certificate chain - loading from user key**. This is expected behavior.
+      #. Load the certificate onto the LEDGER device by running the following script from the extracted folder:
 
-#. The LEDGER device says **Certificate concordium**. Press the right button to navigate through the key, while confirming that it is the following:
+         .. code-block:: console
 
-   - :substitution-code:`|ledger-app-public-key|`
+            $./loadcertificate.sh
 
-and then press both buttons when the LEDGER device says **Trust certificate**.
+      #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. You can safely ignore the message in the command-line window saying **Broken certificate chain - loading from user key**. This is expected behavior.
 
-#. Enter your PIN. The certificate has now been installed on the LEDGER device .
+      #. The LEDGER device says **Certificate concordium**. Press the right button to navigate through the key, while confirming that it is the following:
 
-.. _install-ledger-app-macos:
+         - :substitution-code:`|ledger-app-public-key|`
 
-Install the Concordium LEDGER app on macOS
----------------------------------------------
+      and then press both buttons when the LEDGER device says **Trust certificate**.
 
-#. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
+      #. Enter your PIN. The certificate has now been installed on the LEDGER device.
 
-#. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``.
+   .. group-tab:: Ubuntu
 
-#. Install the Concordium application on the LEDGER device by running the following script from the folder you extracted the files to:
+      #. Close all applications that might be connected to the LEDGER device such as LEDGER LIVE and Concordium Desktop Wallet and keep them closed until you've completed the steps in this guide.
 
-   .. code-block:: console
+      #. Download the ZIP folder with the Concordium LEDGER application.
 
-      $./install.sh
+      #. Extract the files from the ZIP folder to a folder on your computer.
 
-#. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. The LEDGER device says **Loading, please wait** while it installs the app.
+      #. Disconnect the LEDGER device from your computer.
 
-#. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. You can now use the LEDGER device with the Desktop Wallet.
+      #. Now you need to start recovery mode on the LEDGER device.
 
-.. _update-app-macos:
+         - On the LEDGER device, press the *left* button and hold it down while you reconnect the LEDGER device to the computer. Navigate to **Recovery mode** and press both buttons to enter **recovery mode**.
 
-Update/reinstall the Concordium LEDGER app on macOS
----------------------------------------------------
+      #. Enter your PIN code.
 
-For the app to work properly with the current version of the Desktop Wallet, make sure that you update to the latest version of the app.
+      #. Run the following script from the folder you extracted the files to:
 
-When you update your LEDGER device, it should not be necessary to update the certificate.
+         .. code-block:: console
 
-.. Note::
-    If you're using a different computer than the one you used when you installed the app, you must :ref:`install Python3, pip, and the Python tools <install-python-pip-macos>` tools for LEDGER (ledgerblue) before updating the app.
+            $./loadcertificate.sh
 
-#. :ref:`Download the LEDGER app<Ledger-downloads>` if you haven't done so already.
+      #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. You can safely ignore the message in the command-line window saying **Broken certificate chain - loading from user key**. This is expected behavior.
 
-#. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
+      #. The LEDGER device says **Certificate concordium**. Press the right button to navigate through the key, while confirming that it is the following:
 
-#. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-ledger-app-2.0.3-target-2.1.0``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-ledger-app-2.0.3-target-2.1.0``.
+         - :substitution-code:`|ledger-app-public-key|`
 
-#. Install the Concordium application on the LEDGER device by running the following script from the folder you extracted the files to:
+      and then press both buttons when the LEDGER device says **Trust certificate**.
 
-   .. code-block:: console
+      #. Enter your PIN. The certificate has now been installed on the LEDGER device.
 
-      ./install.sh
+Install the Concordium LEDGER app
+================================
 
-.. Note::
+After installing the certificate, you can proceed to install the Concordium LEDGER app. The installation steps vary by operating system.
 
-   If you get the error ``loadApp.py: error: unrecognized arguments: --apiLevel 1`` this means that you have an older version of the Python tools for LEDGER (ledgerblue). To update, run ``$pip3 install ledgerblue --upgrade``.
+.. tabs::
 
-#. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**.
+   .. group-tab:: Windows
 
-#. Before you can install the new version of the LEDGER app, you have to uninstall the old one. The LEDGER device says **Uninstall Concordium**. Press the right button to navigate through the identifier until the LEDGER device says **Confirm action**. Press both buttons to confirm. The LEDGER device says **Loading, please wait** while it installs the app.
+      .. _install-ledger-app-windows:
 
-#. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. Press the left button to verify that you've installed the latest version of the LEDGER app.
+      #. In the folder that you extracted the files to, double-click the ``install.bat`` file. If there's a message saying **Windows protected your PC**, select **More info**, and then select **Run anyway**.
 
-Install Concordium LEDGER app on Ubuntu
-=======================================
+      #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. The LEDGER device says **Loading, please wait** while it installs the app.
 
-Install Python3 and pip on Ubuntu
----------------------------------
+      #. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. You can now use the LEDGER device with the Desktop Wallet.
 
-.. _install-python-pip-ubuntu:
+   .. group-tab:: macOS
 
-#. Add udev rules. For more information, see the Linux section in `LEDGER ‘s guide Fix connection history <https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues>`_.
+      .. _install-ledger-app-macos:
 
-   .. code-block:: console
+      #. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
 
-      $wget -q -O - https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | sudo bash
+      #. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-governance-ledger-app-1.1.0-nanos-2.1.0.zip``.
 
+      #. Install the Concordium application on the LEDGER device by running the following script from the folder you extracted the files to:
 
-2. Install python3:
+         .. code-block:: console
 
-   .. code-block:: console
+            $./install.sh
 
-      $sudo apt-get install python3
+      #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. The LEDGER device says **Loading, please wait** while it installs the app.
 
-3. Install pip:
+      #. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. You can now use the LEDGER device with the Desktop Wallet.
 
-   .. code-block:: console
+   .. group-tab:: Ubuntu
 
-      $sudo apt-get install python3-pip
+      .. _install-ledger-app-ubuntu:
 
-4. Install
+      #. Install the Concordium application on the LEDGER device by running the following script from the folder you extracted the files to:
 
-   .. code-block:: console
+         .. code-block:: console
 
-      $sudo apt-get install libudev-dev libusb-1.0-0-dev python-dev
+            $./install.sh
 
-5. Install ledgerblue:
+      2. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. The LEDGER device says **Loading, please wait** while it installs the app.
 
-   .. code-block:: console
+      3. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. You can now use the LEDGER device with the Desktop Wallet.
 
-      $sudo pip3 install ledgerblue
+Update the Concordium LEDGER app
+===============================
 
-Install the custom certificate on Ubuntu
-----------------------------------------
+For the app to work properly with the current version of the Desktop Wallet, make sure that you update to the latest version of the app. The update process varies by operating system.
 
-You now have to install a custom certificate to ensure that the LEDGER device trusts applications signed by Concordium's private key.
+.. tabs::
 
-#. Close all applications that might be connected to the LEDGER device such as LEDGER LIVE and Concordium Desktop Wallet and keep them closed until you’ve completed the steps in this guide.
+   .. group-tab:: Windows
 
-#. Download the ZIP folder with the Concordium LEDGER application.
+      .. _update-app-windows:
 
-#. Extract the files from the ZIP folder to a folder on your computer.
+      .. Note::
+          Before updating, verify that you have :ref:`installed Python3, pip, and the Python tools <install-python-pip-windows>` for LEDGER (ledgerblue) before updating the app.
 
-#. Disconnect the LEDGER device from your computer.
+      #. :ref:`Download the LEDGER app<Ledger-downloads>` if you haven't done so already.
 
-#. Now you need to start recovery mode on the LEDGER device.
+      #. In the folder that you extracted the files to, double-click the ``install.bat`` file. If there's a message saying **Windows protected your PC**, select **More info**, and then select **Run anyway**.
 
-   - On the LEDGER device, press the *left* button and hold it down while you reconnect the LEDGER device to the computer. Navigate to **Recovery mode** and press both buttons to enter **recovery mode**.
+      .. Note::
 
-#. Enter your PIN code.
+         If you get the error ``loadApp.py: error: unrecognized arguments: --apiLevel 1`` this means that you have an older version of the Python tools for LEDGER (ledgerblue). To update, run ``$pip3 install ledgerblue --upgrade``.
 
-#. Run the following script from the folder you extracted the files to:
+      #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons.
 
-   .. code-block:: console
+      #. Before you can install the new version of the LEDGER app, you have to uninstall the old one. The LEDGER device says **Uninstall Concordium**. Press the right button to navigate through the identifier until the LEDGER device says **Confirm action**. Press both buttons to confirm. The LEDGER device says **Loading, please wait** while it installs the app.
 
-      $./loadcertificate.sh
+      #. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. Press the left button to verify that you've installed the latest version of the LEDGER app.
 
-#. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. You can safely ignore the message in the command-line window saying **Broken certificate chain - loading from user key**. This is expected behavior.
+   .. group-tab:: macOS
 
-#. The LEDGER device says **Certificate concordium**. Press the right button to navigate through the key, while confirming that it is the following:
+      .. _update-app-macos:
 
-   - :substitution-code:`|ledger-app-public-key|`
+      When you update your LEDGER device, it should not be necessary to update the certificate.
 
-and then press both buttons when the LEDGER device says **Trust certificate**.
+      .. Note::
+          If you're using a different computer than the one you used when you installed the app, you must :ref:`install Python3, pip, and the Python tools <install-python-pip-macos>` tools for LEDGER (ledgerblue) before updating the app.
 
-#. Enter your PIN. The certificate has now been installed on the LEDGER device.
+      #. :ref:`Download the LEDGER app<Ledger-downloads>` if you haven't done so already.
 
-.. _install-ledger-app-ubuntu:
+      #. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
 
-Install the Concordium LEDGER app on Ubuntu
--------------------------------------------
+      #. Navigate to where you have downloaded the LEDGER install package. For example, this might be ``~/Downloads/concordium-ledger-app-2.0.3-target-2.1.0``. To navigate to this directory in a Terminal, enter ``cd ~/Downloads/concordium-ledger-app-2.0.3-target-2.1.0``.
 
-#. Install the Concordium application on the LEDGER device by running the following script from the folder you extracted the files to:
+      #. Install the Concordium application on the LEDGER device by running the following script from the folder you extracted the files to:
 
-   .. code-block:: console
+         .. code-block:: console
 
-      $./install.sh
+            $./install.sh
 
-2. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**. Press both buttons. The LEDGER device says **Loading, please wait** while it installs the app.
+      .. Note::
 
-3. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. You can now use the LEDGER device with the Desktop Wallet.
+         If you get the error ``loadApp.py: error: unrecognized arguments: --apiLevel 1`` this means that you have an older version of the Python tools for LEDGER (ledgerblue). To update, run ``$pip3 install ledgerblue --upgrade``.
 
-.. _update-app-ubuntu:
+      #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**.
 
-Update the Concordium LEDGER app on Ubuntu
--------------------------------------------
+      #. Before you can install the new version of the LEDGER app, you have to uninstall the old one. The LEDGER device says **Uninstall Concordium**. Press the right button to navigate through the identifier until the LEDGER device says **Confirm action**. Press both buttons to confirm. The LEDGER device says **Loading, please wait** while it installs the app.
 
-For the app to work properly with the current version of the Desktop Wallet, make sure that you update to the latest version of the app.
+      #. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. Press the left button to verify that you've installed the latest version of the LEDGER app.
 
-.. Note::
-    If you're using a different computer than the one you used when you installed the app, you must :ref:`install Python3, pip, and the Python tools <install-python-pip-ubuntu>` for LEDGER (ledgerblue) before updating the app.
+   .. group-tab:: Ubuntu
 
-#. :ref:`Download <downloads>` the latest version of the LEDGER app if you haven't done so already.
+      .. _update-app-ubuntu:
 
-#. Run the ``install.sh`` file from the folder that you extracted the files to.
+      .. Note::
+          If you're using a different computer than the one you used when you installed the app, you must :ref:`install Python3, pip, and the Python tools <install-python-pip-ubuntu>` for LEDGER (ledgerblue) before updating the app.
 
-.. Note::
+      #. :ref:`Download <downloads>` the latest version of the LEDGER app if you haven't done so already.
 
-   If you get the error ``loadApp.py: error: unrecognized arguments: --apiLevel 1`` this means that you have an older version of the Python tools for LEDGER (ledgerblue). To update, run ``$sudo pip3 install ledgerblue --upgrade``.
+      #. Run the ``install.sh`` file from the folder that you extracted the files to.
 
-#. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**.
+      .. Note::
 
-#. Before you can install the new version of the LEDGER app, you have to uninstall the old one. The LEDGER device says **Uninstall Concordium**. Press the right button to navigate through the identifier until the LEDGER device says **Confirm action**. Press both buttons to confirm. The LEDGER device says **Loading, please wait** while it installs the app.
+         If you get the error ``loadApp.py: error: unrecognized arguments: --apiLevel 1`` this means that you have an older version of the Python tools for LEDGER (ledgerblue). To update, run ``$sudo pip3 install ledgerblue --upgrade``.
 
-#. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. Press the left button to verify that you've installed the latest version of the LEDGER app.
+      #. The LEDGER device says **Deny unsafe manager**. Press the right button to navigate through the public key until the LEDGER device says **Allow unsafe manager**.
+
+      #. Before you can install the new version of the LEDGER app, you have to uninstall the old one. The LEDGER device says **Uninstall Concordium**. Press the right button to navigate through the identifier until the LEDGER device says **Confirm action**. Press both buttons to confirm. The LEDGER device says **Loading, please wait** while it installs the app.
+
+      #. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. Press the left button to verify that you've installed the latest version of the LEDGER app.

--- a/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
+++ b/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
@@ -5,6 +5,8 @@
 .. |nano-s-firmware| replace:: **2.1.0**
 .. |nano-s-plus-firmware| replace:: **1.4.0**
 .. |ccd-governance-version| replace:: **1.2.0**
+.. _dl-nanos: https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.2.0/concordium-governance-ledger-app-1.2.0-nanos-2.1.0.zip
+.. _dl-nanosp: https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.2.0/concordium-governance-ledger-app-1.2.0-nanosplus.zip
 
 .. _install-Ledger-app:
 
@@ -205,13 +207,13 @@ Once you have updated the firmware version, you can download the LEDGER app:
 
    .. group-tab:: Nano S
 
-      #. `Download the Concordium Governance LEDGER App for LEDGER Nano S <https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.2.0/concordium-governance-ledger-app-1.2.0-nanos-2.1.0.zip>`_
+      #. `Download the Concordium Governance LEDGER App for LEDGER Nano S <dl-nanos_>`_
 
       #. Extract the files from the ``.zip`` folder to a folder on your computer.
 
    .. group-tab:: Nano S+
 
-      #. `Download the Concordium Governance LEDGER App for LEDGER Nano S+ <https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.2.0/concordium-governance-ledger-app-1.2.0-nanosplus.zip>`_
+      #. `Download the Concordium Governance LEDGER App for LEDGER Nano S+ <dl-nanosp_>`_
 
       #. Extract the files from the ``.zip`` folder to a folder on your computer.
 

--- a/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
+++ b/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
@@ -99,7 +99,7 @@ To update the LEDGER device firmware, do the following:
       For details on how to update the LEDGER firmware, see `LEDGER NANO S PLUS guide <https://support.ledger.com/hc/en-us/articles/4445777839901-Update-Ledger-Nano-S-Plus-firmware?docs=true>`_.
 
 Install Python and pip
-=====================
+======================
 
 You need to install Python and pip to proceed with installing the Concordium LEDGER app. The installation steps depend on your operating system.
 
@@ -205,13 +205,13 @@ Once you have updated the firmware version, you can download the LEDGER app:
 
    .. group-tab:: Nano S
 
-      #. `Download the Concordium Governance LEDGER App for LEDGER <https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.2.0/concordium-governance-ledger-app-1.2.0-nanos-2.1.0.zip>`_
+      #. `Download the Concordium Governance LEDGER App for LEDGER Nano S <https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.2.0/concordium-governance-ledger-app-1.2.0-nanos-2.1.0.zip>`_
 
       #. Extract the files from the ``.zip`` folder to a folder on your computer.
 
    .. group-tab:: Nano S+
 
-      #. `Download the Concordium Governance LEDGER App for LEDGER <https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.2.0/concordium-governance-ledger-app-1.2.0-nanosplus.zip>`_
+      #. `Download the Concordium Governance LEDGER App for LEDGER Nano S+ <https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.2.0/concordium-governance-ledger-app-1.2.0-nanosplus.zip>`_
 
       #. Extract the files from the ``.zip`` folder to a folder on your computer.
 
@@ -267,7 +267,7 @@ You need to install a custom certificate to ensure that the LEDGER device trusts
       #. Navigate to where you have downloaded and extracted the LEDGER install package. For example to navigate to the default download directory in a Terminal, enter
 
          .. tabs::
- 
+
             .. group-tab:: Nano S
 
                .. code-block:: console
@@ -392,7 +392,7 @@ After installing the certificate, you can proceed to install the Concordium LEDG
       3. The LEDGER device says **Concordium**. Press both buttons. The LEDGER device says **Concordium is ready**. You can now use the LEDGER device with the Desktop Wallet.
 
 Update the Concordium LEDGER app
-===============================
+================================
 
 For the app to work properly with the current version of the Desktop Wallet, make sure that you update to the latest version of the app.
 

--- a/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
+++ b/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
@@ -82,8 +82,6 @@ To update the LEDGER device firmware, do the following:
 
           - If it says |nano-s-firmware|, you don't have to update the firmware. If there's a lower version number, you'll have to update the firmware.
 
-      For details on how to update the LEDGER firmware, see `LEDGER NANO S guide <https://support.ledger.com/hc/en-us/articles/4445777839901-Update-Ledger-Nano-S-Plus-firmware?docs=true>`_.
-
    .. group-tab:: Nano S+
 
       #. On the LEDGER device press both buttons for a little while until the Settings icon appears. Press both buttons to enter the Settings menu.
@@ -96,7 +94,9 @@ To update the LEDGER device firmware, do the following:
 
           - If it says |nano-s-plus-firmware|, you don't have to update the firmware. If there's a lower version number, you'll have to update the firmware.
 
-      For details on how to update the LEDGER firmware, see `LEDGER NANO S PLUS guide <https://support.ledger.com/hc/en-us/articles/4445777839901-Update-Ledger-Nano-S-Plus-firmware?docs=true>`_.
+.. note::
+
+   For details on how to update the LEDGER firmware, see `LEDGER NANO S PLUS guide <https://support.ledger.com/article/360013349800-zd>`_.
 
 Install Python and pip
 ======================
@@ -151,7 +151,7 @@ You need to install Python and pip to proceed with installing the Concordium LED
 
             $brew install python@3 libusb libjpeg
 
-         You can use `pyenv<https://github.com/pyenv/pyenv>` if you need multiple python versions. Installing libjpeg is only necessary if you have a Mac with an M1 or similar Apple Silicon CPU.
+         You can use `pyenv <https://github.com/pyenv/pyenv>`_ if you need multiple python versions. Installing libjpeg is only necessary if you have a Mac with an M1 or similar Apple Silicon CPU.
 
       #. To install ledgerblue, copy the following into the Terminal and press Enter:
 
@@ -163,7 +163,7 @@ You need to install Python and pip to proceed with installing the Concordium LED
 
       .. _install-python-pip-ubuntu:
 
-      #. Add udev rules. For more information, see the Linux section in `LEDGER 's guide Fix connection history <https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues>`_.
+      #. Add udev rules. For more information, see the Linux section in `LEDGER 's guide Fix connection history <https://support.ledger.com/article/115005165269-zd>`_.
 
          .. code-block:: console
 
@@ -266,21 +266,28 @@ You need to install a custom certificate to ensure that the LEDGER device trusts
 
       #. Navigate to where you have downloaded and extracted the LEDGER install package. For example to navigate to the default download directory in a Terminal, enter
 
-         .. tabs::
+         .. code-block:: console
+            :substitutions:
 
-            .. group-tab:: Nano S
+            $cd ~/Downloads/concordium-governance-ledger-app-|ccd-governance-version|-nanos-|nano-s-firmware|
 
-               .. code-block:: console
-                  :substitutions:
-
-                  $cd ~/Downloads/concordium-governance-ledger-app-|ccd-governance-version|-nanos-|nano-s-firmware|
-
-            .. group-tab:: Nano S+
-
-               .. code-block:: console
-                  :substitutions:
-
-                  $cd ~/Downloads/concordium-governance-ledger-app-|ccd-governance-version|-nanosplus
+         .. For now, setting up custom CAs on Nano S+ does not make any difference, as sideloading signed apps is not working.
+         ..
+         .. .. tabs::
+         ..
+         ..    .. group-tab:: Nano S
+         ..
+         ..       .. code-block:: console
+         ..          :substitutions:
+         ..
+         ..          $cd ~/Downloads/concordium-governance-ledger-app-|ccd-governance-version|-nanos-|nano-s-firmware|
+         ..
+         ..    .. group-tab:: Nano S+
+         ..
+         ..       .. code-block:: console
+         ..          :substitutions:
+         ..
+         ..          $cd ~/Downloads/concordium-governance-ledger-app-|ccd-governance-version|-nanosplus
 
       #. Load the certificate onto the LEDGER device by running the following script from the extracted folder:
 
@@ -473,7 +480,7 @@ For the app to work properly with the current version of the Desktop Wallet, mak
       .. Note::
           If you're using a different computer than the one you used when you installed the app, you must :ref:`install Python3, pip, and the Python tools <install-python-pip-ubuntu>` for LEDGER (ledgerblue) before updating the app.
 
-      #. :ref:`Download <downloads>` the latest version of the LEDGER app if you haven't done so already.
+      #. :ref:`Download <Ledger-downloads>` the latest version of the LEDGER app if you haven't done so already.
 
       #. Run the ``install.sh`` file from the folder that you extracted the files to.
 

--- a/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
+++ b/source/mainnet/docs/desktop-wallet/install-ledger-app.rst
@@ -208,7 +208,6 @@ Once you have updated the firmware version, you can download the LEDGER app:
       #. `Download the Concordium Governance LEDGER App for LEDGER <https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.2.0/concordium-governance-ledger-app-1.2.0-nanos-2.1.0.zip>`_
 
       #. Extract the files from the ``.zip`` folder to a folder on your computer.
-      
 
    .. group-tab:: Nano S+
 
@@ -265,10 +264,10 @@ You need to install a custom certificate to ensure that the LEDGER device trusts
 
       #. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
 
-      #. Navigate to where you have downloaded and extracted the LEDGER install package. For example to navigate to the default download directory in a Terminal, enter 
+      #. Navigate to where you have downloaded and extracted the LEDGER install package. For example to navigate to the default download directory in a Terminal, enter
 
          .. tabs::
-            
+ 
             .. group-tab:: Nano S
 
                .. code-block:: console
@@ -350,10 +349,10 @@ After installing the certificate, you can proceed to install the Concordium LEDG
 
       #. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
 
-      #. Navigate to where you have downloaded and extracted the LEDGER install package. For example to navigate to the default download directory in a Terminal, enter 
+      #. Navigate to where you have downloaded and extracted the LEDGER install package. For example to navigate to the default download directory in a Terminal, enter
 
          .. tabs::
-            
+
             .. group-tab:: Nano S
 
                .. code-block:: console
@@ -433,10 +432,10 @@ For the app to work properly with the current version of the Desktop Wallet, mak
 
       #. Open the `Terminal <https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac>`_ application.
 
-      #. Navigate to where you have downloaded the LEDGER install package. For example to navigate to the default download directory in a Terminal, enter 
+      #. Navigate to where you have downloaded the LEDGER install package. For example to navigate to the default download directory in a Terminal, enter
 
          .. tabs::
-            
+
             .. group-tab:: Nano S
 
                .. code-block:: console

--- a/source/mainnet/docs/guides/setup-wallets-lp.rst
+++ b/source/mainnet/docs/guides/setup-wallets-lp.rst
@@ -10,9 +10,10 @@ Choose your wallet for instructions about installation and configuration.
 .. toctree::
    :maxdepth: 1
 
-   Set up the CryptoX Concordium Wallet <../guides/setup-cryptox-wallet>
+   Set up the CryptoX Concordium Wallet <setup-cryptox-wallet>
    Set up the Concordium Wallet for Web <../browser-wallet/setup-browser-wallet>
    Set up the Desktop Wallet <overview-desktop>
    Use your Ledger Device with Concordium Desktop Wallet <ledger-tutorial>
+   Set up Concordium Governance Ledger App <../desktop-wallet/install-ledger-app>
 
 


### PR DESCRIPTION
## Purpose

Update the docs to include instructions for how to install the latest version of the governance ledger app for both ledger nano s/s+.

Took the liberty to also group content by OS and ledger device to make it easier for the reader to filter the content necessary to read.
