### PR TITLE
Remove incorrect pre-deployment note from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,10 +58,6 @@ The build runs with `-W` (warnings as errors). Fix all warnings before committin
 cargo run generate --output_folder <path-to-grpc-json-schema-folder>
 ```
 
-## Pre-deployment checklist
-
-Before deploying to production, revert `source/_templates/navbar-logo.html` so the logo links to `https://developer.concordium.software/` instead of `{{ pathto('index') }}`. This was intentionally left as a local link to make PR preview navigation work correctly.
-
 ## Git
 
 When staging files, never add the entire `.claude/` folder. Only commit files inside `.claude/commands/` — the rest of `.claude/` contains local session data and personal settings that should not be shared.


### PR DESCRIPTION
The navbar-logo.html was already using pathto('index') correctly and never needed to be changed before deployment.

## Purpose

Remove an incorrect pre-deployment note from CLAUDE.md that said navbar-logo.html needed to be changed before deployment. The file was already correct and no change was ever needed..

## Changes

Removed the pre-deployment checklist section from CLAUDE.md.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

