### PR TITLE
Add llms.txt maintenance steps to /add-doc and /remove-doc commands

### DIFF
--- a/.claude/commands/add-doc.md
+++ b/.claude/commands/add-doc.md
@@ -109,6 +109,15 @@ Add a `:doc:` entry for the new page under the correct section heading in the tw
 
 The rules for map labels are in `CLAUDE.md` under *Documentation Maintenance*.
 
-## Step 8: Confirm
+## Step 8: Update llms.txt
+
+Check whether the new page should be listed in `public/llms.txt` as a key entry point. Ask the maintainer: "Should this page be added to llms.txt as a key entry point for AI assistants? This is appropriate for pages that cover important concepts, common tasks, or major features that developers are likely to ask about."
+
+If yes, add an entry under the correct section in `public/llms.txt` following the existing format:
+```
+- [Nav label](https://docs.concordium.com/en/mainnet/<path>.html): Short description
+```
+
+## Step 9: Confirm
 
 Show the maintainer a summary of everything that was created or changed and ask them to review.

--- a/.claude/commands/remove-doc.md
+++ b/.claude/commands/remove-doc.md
@@ -26,6 +26,10 @@ Find the toctree in the parent `index.rst` that references this page and remove 
 
 Find the `:doc:` entry for this page in the relevant section landing page map and remove it. If the page had sub-page entries listed below it, remove those too. If removing the entry leaves a section heading with no entries, remove the heading as well.
 
-## Step 6: Confirm
+## Step 6: Update llms.txt
+
+Check whether the removed page is listed in `public/llms.txt`. If it is, remove the entry. If the removal leaves a section with no entries, remove the section heading as well.
+
+## Step 7: Confirm
 
 Show the maintainer a summary of everything that was removed or changed and ask them to review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,9 @@ The four section landing pages each contain a **manually maintained document map
 ### Why manual maps?
 
 An automatic approach (visible toctrees with `maxdepth: 2`) was considered but rejected because it renders plain indented lists instead of the current two-column grid layout. The manual maps look significantly better and the maintenance overhead is low when AI handles the updates as part of every structural change.
+
+### llms.txt
+
+`public/llms.txt` is a machine-readable index of key entry points in the documentation, following the [llms.txt standard](https://llmstxt.org/). It helps AI assistants discover and understand the documentation structure.
+
+**Keep it current:** When adding or removing a page that covers an important concept, common task, or major feature, update `public/llms.txt` accordingly. The `/add-doc` and `/remove-doc` commands include a step for this.


### PR DESCRIPTION
The /add-doc command now asks whether the new page should be listed in llms.txt as a key entry point. The /remove-doc command now checks whether the removed page is listed and removes it if so. CLAUDE.md documents the purpose of llms.txt and points to the commands for maintenance.

## Purpose

Follow-up to the llms.txt PR — ensures the file stays current as pages are added or removed.

## Changes

- /add-doc command: added a step asking whether the new page should be listed in public/llms.txt as a key entry point for AI assistants
- /remove-doc command: added a step checking whether the removed page is listed in public/llms.txt and removing it if so
- CLAUDE.md: added a "llms.txt" subsection under Documentation Maintenance explaining the file's purpose and pointing to the commands

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf
