### PR TITLE
Add Agent Registry documentation (CIS-8, CIS-8004, MCP service, Indexer)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -57,6 +57,17 @@ Technical specifications, APIs, tools, and release notes.
 - [Release notes](https://docs.concordium.com/en/mainnet/technical-reference/release-notes.html): Node and tool release history
 - [Downloads](https://docs.concordium.com/en/mainnet/downloads.html): Wallets, node software, and tools
 
+## Agent Registry
+
+On-chain identity and discovery for AI agents.
+
+- [Use the Agent Registry](https://docs.concordium.com/en/mainnet/how-to/integrations/agent-registry.html): Register an agent, link an Ethereum address, and publish a verifiable Agent Card
+- [CIS-8004: Agent Registry standard](https://docs.concordium.com/en/mainnet/technical-reference/agent-registry/cis-8004.html): CIS-8004 contract specification — token model, entrypoints, and external references
+- [CIS-8: External Key Registry standard](https://docs.concordium.com/en/mainnet/technical-reference/agent-registry/cis-8.html): CIS-8 contract specification — cross-chain key bindings and proof schemes
+- [Agent Card format](https://docs.concordium.com/en/mainnet/technical-reference/agent-registry/agent-card.html): Agent Card JSON structure, Concordium extension block, and card verification
+- [MCP service](https://docs.concordium.com/en/mainnet/technical-reference/agent-registry/mcp-service.html): Model Context Protocol server — hosted endpoint, local setup, and all available tools
+- [Indexer](https://docs.concordium.com/en/mainnet/technical-reference/agent-registry/indexer.html): Event indexer for agent discovery — setup, REST API, and sync state
+
 ## Optional
 
 - [Onboard as an exchange](https://docs.concordium.com/en/mainnet/how-to/integrations/exchange-onboarding.html): Integration guide for cryptocurrency exchanges

--- a/source/mainnet/how-to/index.rst
+++ b/source/mainnet/how-to/index.rst
@@ -52,6 +52,7 @@ Step-by-step guides for completing specific tasks on Concordium. Browse all guid
         - :doc:`Create proofs <web3-id/create-proofs>`
 
       - :doc:`Implement X402 payments <integrations/x402-integration>`
+      - :doc:`Use the Agent Registry <integrations/agent-registry>`
 
       **Validation**
 
@@ -136,6 +137,7 @@ Step-by-step guides for completing specific tasks on Concordium. Browse all guid
    Integrate Concordium in a crypto wallet <integrations/wallet-integration/wallet-integration>
    Implement Web3 ID <web3-id/index>
    Implement X402 payments <integrations/x402-integration>
+   Use the Agent Registry <integrations/agent-registry>
 
 .. toctree::
    :caption: Validation

--- a/source/mainnet/how-to/integrations/agent-registry.rst
+++ b/source/mainnet/how-to/integrations/agent-registry.rst
@@ -1,0 +1,110 @@
+.. include:: ../../variables.rst
+.. _agent-registry-how-to:
+
+==========================
+Use the Agent Registry
+==========================
+
+.. admonition:: At a glance
+
+   This guide explains what the Concordium Agent Registry is, how native Concordium accounts differ from Ethereum-style addresses in this context, and what an Agent Card is. You will end the guide knowing how to register an agent, link an external key, and publish a verifiable Agent Card — whether you are coming from a Concordium-native background or from the Ethereum ecosystem.
+
+The Agent Registry is an on-chain system that gives AI agents a persistent, verifiable identity on Concordium. Each agent is represented as a non-fungible token (an NFT minted under the :ref:`CIS-8004 <cis-8004>` standard) that carries a public URL pointing to an :ref:`Agent Card <agent-card>` — a JSON document describing the agent's name, capabilities, and service endpoints.
+
+Because the registry is built on Concordium's identity layer, agents can be linked to verified human owners, making trust in agentic transactions concrete rather than speculative.
+
+Native and external accounts
+=============================
+
+**Native accounts** are the standard Concordium account type — a Base58-encoded address derived from one or more cryptographic key pairs managed in a Concordium wallet. Every on-chain action in the registry (minting, transferring, revoking) is signed by the native account that owns the agent.
+
+**External accounts** — most commonly Ethereum addresses — can also be linked to the registry through the :ref:`CIS-8 External Key Registry <cis-8>`. CIS-8 records a cryptographic proof on-chain that a given Ethereum (or Solana, Cosmos, or Fetch.ai) public key is controlled by the same person who controls a specific Concordium native account. Once that proof exists, a CIS-8004 agent can carry a ``Cis8`` external reference that exposes the Ethereum address to any tooling that knows how to read CIS-8 bindings.
+
+The result is that agents are fully interoperable: Concordium tools address agents by token ID or native owner; Ethereum-side tooling addresses them by Ethereum public key; both resolve to the same on-chain NFT.
+
+What is an Agent Card?
+=======================
+
+An Agent Card is a JSON file hosted at a public URL (the ``agent_uri`` of the registered agent). It is the agent's public identity document and contains:
+
+- **Name and description** — human-readable metadata about what the agent does.
+- **Skills** — a structured list of the capabilities the agent exposes, each with an ID, a name, a description, and optional tags.
+- **Provider** — the organisation responsible for operating the agent.
+- **Services** — named endpoint URLs the agent exposes to other agents (for example, a tipping MCP endpoint).
+- **Concordium extension block** — on-chain coordinates: the CAIP-2 chain ID, the canonical token address, the CIS-8004 and CIS-8 contract addresses, and the owner account.
+
+The SHA-256 hash of the card's raw bytes is stored on-chain as the ``metadata_hash``. Any consumer can re-fetch the card, recompute the hash, and confirm it matches the on-chain value — this is what the MCP tool ``verify_agent_card`` does automatically.
+
+The card format is compatible with the A2A (Agent-to-Agent) protocol, so agents registered on Concordium are discoverable by any A2A-compatible framework.
+
+Register a native agent
+========================
+
+1. **Generate the Agent Card JSON** using the MCP tool ``build_agent_card``. Supply the agent's name, description, skills, your Concordium owner account, and the URL where you will host the card. The tool returns the JSON and its SHA-256 hash.
+
+2. **Host the card** at the URL you specified. The URL must be publicly reachable and must serve exactly the bytes the tool returned (no reformatting).
+
+3. **Register on-chain** using ``build_register``. Pass the ``agent_uri``, the ``metadata_hash_hex`` from step 1, and your Concordium sender account. The tool returns a sign-ready transaction payload.
+
+4. **Sign and submit** the payload with your Concordium wallet. On success, a new agent NFT is minted and you receive its ``token_id``.
+
+5. **Confirm** by calling ``verify_agent_card`` with the new ``token_id``. It returns ``match: true`` when the on-chain hash and the hosted card agree.
+
+Register with a linked Ethereum address
+=========================================
+
+Follow these steps to give your agent an on-chain link to an Ethereum address in addition to its Concordium native owner.
+
+Step 1: Derive the canonical bytes
+------------------------------------
+
+Call ``build_cis8_canonical_bytes`` with:
+
+- ``concordium_account``: your Concordium Base58 account address.
+- ``external_namespace``: the CAIP-2 identifier of the Ethereum chain, e.g. ``eip155:1`` for Ethereum mainnet.
+- ``external_key_namespace``: same value as ``external_namespace``.
+- ``external_key_type``: ``secp256k1-uncompressed``.
+- ``external_public_key_hex``: the uncompressed Ethereum public key, hex-encoded without ``0x``.
+- ``proof_scheme``: ``ethereum-personal-sign``.
+
+The tool returns a hex string of canonical bytes.
+
+Step 2: Sign with the Ethereum key
+------------------------------------
+
+Using your Ethereum wallet or library, sign the canonical bytes using the ``eth_sign`` / personal-sign method (which prepends the Ethereum message prefix and applies keccak256 before signing). Record the resulting signature as a hex string.
+
+Step 3: Submit the CIS-8 registration
+---------------------------------------
+
+Call ``build_cis8_register`` with the external key record (namespace, key type, public key) and the proof (scheme ``ethereum-personal-sign``, signature hex). Sign and submit the returned payload with your Concordium account.
+
+Step 4: Register the agent with the Cis8 reference
+------------------------------------------------------
+
+Call ``build_register`` with an ``external_reference`` of kind ``Cis8`` pointing at the CIS-8 contract (index ``10081``, subindex ``0``) and the external key fields. Include ``agent_uri`` and ``metadata_hash_hex`` as in the native flow.
+
+Sign and submit the payload with your Concordium account. The resulting agent NFT is now resolvable both by its Concordium token ID and by the linked Ethereum address.
+
+Update an agent card
+=====================
+
+When the card content changes, update both the hosted file and the on-chain hash:
+
+1. Regenerate the card JSON (or edit it manually — the ``concordium`` block fields must remain accurate).
+2. Re-host the updated file at the same ``agent_uri``, or at a new URL.
+3. Call ``build_set_agent_uri`` with the ``token_id``, the (possibly new) ``agent_uri``, and the SHA-256 hash of the new card bytes.
+4. Sign and submit the payload.
+
+Transfer an agent
+==================
+
+Agents are CIS-2 NFTs and can be transferred to a new Concordium owner using ``build_transfer``. Transferring an agent automatically clears the ``agentWallet`` metadata key — the new owner must set a new payment wallet if they want one.
+
+Next steps
+==========
+
+- :ref:`CIS-8004 reference <cis-8004>` — full entrypoint and state specification.
+- :ref:`CIS-8 reference <cis-8>` — cross-chain key binding details and supported proof schemes.
+- :ref:`Agent Card reference <agent-card>` — complete field-by-field card specification.
+- :ref:`MCP service reference <agent-registry-mcp>` — all available tools and configuration options.

--- a/source/mainnet/technical-reference/agent-registry/agent-card.rst
+++ b/source/mainnet/technical-reference/agent-registry/agent-card.rst
@@ -1,0 +1,132 @@
+.. include:: ../../variables.rst
+.. _agent-card:
+
+==========
+Agent Card
+==========
+
+An Agent Card is a JSON document that describes a registered AI agent: its identity, capabilities, service endpoints, and on-chain coordinates. It is hosted at a public URL (the agent's ``agent_uri``) and its integrity is protected by a SHA-256 hash anchored on-chain in the :doc:`CIS-8004 <cis-8004>` contract.
+
+Any consumer — another agent, an AI development tool, or a human — can verify a card by fetching ``agent_uri``, computing the SHA-256 hash of the raw response body, and comparing it to the ``metadata_hash`` stored on-chain. The MCP tool ``verify_agent_card`` performs this check automatically.
+
+Concordium's Agent Card format is compatible with the A2A (Agent-to-Agent) protocol card format and adds a ``concordium`` extension block that carries the on-chain identifiers needed for cross-chain discovery.
+
+Top-level fields
+================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Field
+     - Type
+     - Description
+   * - ``name``
+     - string
+     - Display name of the agent. Maximum 128 characters.
+   * - ``description``
+     - string
+     - Human-readable description of what the agent does. Maximum 2048 characters.
+   * - ``version``
+     - string
+     - Semantic version of the agent (e.g. ``1.0.0``).
+   * - ``url``
+     - URI
+     - Canonical URL where this card is hosted. Must match the ``agent_uri`` registered on-chain.
+   * - ``provider``
+     - object (optional)
+     - The organisation that operates the agent. Has ``organization`` (string) and ``url`` (URI) sub-fields.
+   * - ``skills``
+     - array
+     - Capabilities the agent exposes. Each entry has ``id``, ``name``, ``description``, and ``tags`` (string array).
+   * - ``documentationUrl``
+     - URI (optional)
+     - Link to extended documentation.
+   * - ``concordium``
+     - object
+     - Concordium-specific extension block. See below.
+
+Concordium extension block
+==========================
+
+The ``concordium`` object is injected automatically by the MCP tool ``build_agent_card``. It carries every on-chain identifier that a consuming system needs to locate and verify the agent without prior Concordium knowledge.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Field
+     - Description
+   * - ``chain_id``
+     - CAIP-2 chain identifier for the network the agent is registered on. For mainnet: ``concordium:mainnet``.
+   * - ``token_address``
+     - Base58Check CIS-2 token address derived from ``(contract_index=10082, subindex=0, token_id)``. Uniquely identifies the agent across Concordium tooling.
+   * - ``cis8004_contract``
+     - JSON object ``{"index": 10082, "subindex": 0}`` — the Agent Registry contract address.
+   * - ``cis8_contract``
+     - JSON object ``{"index": 10081, "subindex": 0}`` — the External Key Registry contract address.
+   * - ``owner``
+     - Base58 Concordium account address of the agent's current owner.
+   * - ``services``
+     - Optional key-value map of named service endpoints. For example, ``{"tippingMcp": "https://..."}`` exposes an MCP endpoint that other agents can call to tip this agent. Keys and values are free-form strings.
+
+Example card
+============
+
+.. code-block:: json
+
+   {
+     "name": "Market Data Agent",
+     "description": "Fetches and summarises real-time CCD/EUR market data on demand.",
+     "version": "1.0.0",
+     "url": "https://agents.example.com/market-data/card.json",
+     "provider": {
+       "organization": "Example Labs",
+       "url": "https://example.com"
+     },
+     "skills": [
+       {
+         "id": "fetch-price",
+         "name": "Fetch price",
+         "description": "Returns the current CCD/EUR mid-market price.",
+         "tags": ["market", "price", "ccd"]
+       },
+       {
+         "id": "summarise-day",
+         "name": "Summarise day",
+         "description": "Returns a one-paragraph summary of today's CCD price action.",
+         "tags": ["market", "summary", "ccd"]
+       }
+     ],
+     "concordium": {
+       "chain_id": "concordium:mainnet",
+       "token_address": "TKN1A2B3C4...",
+       "cis8004_contract": {"index": 10082, "subindex": 0},
+       "cis8_contract": {"index": 10081, "subindex": 0},
+       "owner": "3z9dkoTnLi2HEZvjnmKrMec2Gk2NKcEhdi4PugDWzP4GQtZiFa",
+       "services": {
+         "tippingMcp": "https://agents.example.com/market-data/mcp"
+       }
+     }
+   }
+
+Building and hosting a card
+============================
+
+Use the MCP tool ``build_agent_card`` to generate a valid card JSON. The tool accepts human-readable inputs (name, description, skills, owner account, and an optional ``token_id`` if the agent is already registered) and injects all Concordium-specific fields automatically. It returns the canonical JSON and its SHA-256 hash.
+
+After receiving the JSON:
+
+1. Host the file at a stable public URL (``agent_uri``).
+2. Pass the SHA-256 hash to ``build_set_agent_uri`` (for an existing agent) or ``build_register`` (when registering a new agent) so the hash is anchored on-chain.
+
+Whenever you update the card content you must update ``agent_uri`` and ``metadata_hash`` on-chain via ``build_set_agent_uri`` to keep the integrity anchor current.
+
+Card verification
+=================
+
+The MCP tool ``verify_agent_card`` performs the full verification cycle for a given ``token_id``:
+
+1. Reads ``agent_uri`` and ``metadata_hash`` from the chain.
+2. Fetches the URL and computes the SHA-256 of the response body.
+3. Returns ``match: true`` when both hashes are present and equal, ``match: false`` on mismatch, and ``match: null`` when either side is absent (e.g. the agent has not yet set an ``agent_uri``).

--- a/source/mainnet/technical-reference/agent-registry/cis-8.rst
+++ b/source/mainnet/technical-reference/agent-registry/cis-8.rst
@@ -1,0 +1,119 @@
+.. include:: ../../variables.rst
+.. _cis-8:
+
+==============================
+CIS-8: External Key Registry
+==============================
+
+CIS-8 is the Concordium External Key Registry standard. It records cryptographically-proven bindings between Concordium native accounts and public keys from external chains — Ethereum, Solana, Cosmos, Fetch.ai, and any other chain whose signature scheme is supported.
+
+A CIS-8 binding is the foundation for cross-chain agent ownership: an agent registered in :doc:`CIS-8004 <cis-8004>` can carry a ``Cis8`` external reference that links it to an Ethereum address, making the agent discoverable and attributable from outside the Concordium ecosystem without sacrificing the compliance properties that come with Concordium's identity layer.
+
+Mainnet contract: index ``10081``, subindex ``0``.
+
+How a binding works
+===================
+
+A binding records three things on-chain:
+
+1. **The Concordium account** — the Base58 native account that claims control of the external key.
+2. **The external key** — the namespace, key type, and hex-encoded public key of the external address.
+3. **The proof** — a signature by the external key over a canonical byte string, proving that the Concordium account holder also controls the external private key.
+
+The canonical bytes that the external key must sign are deterministically derived from the Concordium account address, the external key fields, and the proof scheme. Use the MCP service tool ``build_cis8_canonical_bytes`` to obtain the exact bytes before signing.
+
+The registration call (``build_cis8_register``) carries both the external key record and the proof. The contract verifies the signature on-chain and records the binding if it is valid.
+
+External key format
+===================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Field
+     - Type
+     - Description
+   * - ``namespace``
+     - string
+     - CAIP-2 chain identifier. For Ethereum mainnet: ``eip155:1``. For Solana: ``solana:mainnet``.
+   * - ``key_type``
+     - string
+     - Encoding of the public key. Common values: ``secp256k1-uncompressed`` (Ethereum/Cosmos), ``ed25519`` (Solana, Fetch.ai).
+   * - ``public_key_hex``
+     - hex string
+     - The raw public key bytes, hex-encoded without ``0x`` prefix.
+
+Proof format
+============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Field
+     - Type
+     - Description
+   * - ``scheme``
+     - string
+     - The signing scheme used. See supported schemes below.
+   * - ``signature_hex``
+     - hex string
+     - The signature bytes, hex-encoded without ``0x`` prefix.
+
+Supported proof schemes
+-----------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Scheme name
+     - Chain
+     - How signing works
+   * - ``ethereum-personal-sign``
+     - Ethereum
+     - Prepends ``\x19Ethereum Signed Message:\n<len>`` before the canonical bytes, then applies keccak256 and signs with secp256k1.
+   * - ``solana-ed25519``
+     - Solana
+     - Signs the canonical bytes directly with ed25519.
+   * - ``cosmos-secp256k1``
+     - Cosmos
+     - Signs the canonical bytes with secp256k1 using the Cosmos signature format.
+   * - ``fetch-ai-ed25519``
+     - Fetch.ai
+     - Signs the canonical bytes with ed25519.
+
+Registration workflow
+=====================
+
+1. Derive the canonical bytes with ``build_cis8_canonical_bytes``, supplying the Concordium account, the external key fields, and the proof scheme.
+2. Sign those bytes with the external key using the appropriate scheme.
+3. Call ``build_cis8_register`` with the external key record, the proof (scheme + signature), and the Concordium sender account. The tool returns a sign-ready transaction payload.
+4. Sign the transaction with the Concordium account's keys and submit it to the network.
+
+Contract entrypoints
+====================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Entrypoint
+     - Description
+   * - ``register``
+     - Records a new binding. Callable only by the Concordium account named in the call. Verifies the external-key signature on-chain.
+   * - ``revoke``
+     - Removes an existing binding. Callable by the account that created it.
+   * - ``updateMetadata``
+     - Stores or updates arbitrary key-value metadata on a binding. The key is a UTF-8 string of at most 64 bytes; the value is opaque bytes.
+
+On-chain lookup
+===============
+
+Given an external key (namespace + key type + public key), the MCP tool ``owner_of_key`` returns the Concordium account that registered that key, or null if no binding exists. The complementary tool ``agent_by_external_reference`` looks up a CIS-8004 agent that carries a matching ``Cis8`` external reference.
+
+Metadata key
+============
+
+The reserved on-chain metadata key ``agentWallet`` is shared with the CIS-8004 Agent Registry and represents the payment wallet address for the agent. Setting it on a CIS-8 binding ties the payment wallet to the cross-chain identity.

--- a/source/mainnet/technical-reference/agent-registry/cis-8004.rst
+++ b/source/mainnet/technical-reference/agent-registry/cis-8004.rst
@@ -1,0 +1,105 @@
+.. include:: ../../variables.rst
+.. _cis-8004:
+
+==============================
+CIS-8004: Agent Registry
+==============================
+
+CIS-8004 is the Concordium Agent Registry standard. It mints each registered AI agent as a non-fungible CIS-2 token, giving it a stable on-chain identity that is discoverable, transferable, and interoperable with the broader multi-chain agent ecosystem.
+
+The standard is designed to be compatible with ERC-8004 (the Ethereum trustless agent standard), so agents registered on Concordium are addressable from Ethereum tooling and vice versa. Concordium extends the baseline specification with support for the :doc:`CIS-8 External Key Registry <cis-8>` cross-chain key bindings and Concordium's own verified-identity layer.
+
+Mainnet contract: index ``10082``, subindex ``0``. The contract advertises support for CIS-0, CIS-2, and CIS-8004.
+
+Agent token
+===========
+
+Each registered agent is represented as a CIS-2 non-fungible token with a unique ``token_id`` (a u64 integer). All standard CIS-2 operations apply: agents can be transferred, burned, and queried using any CIS-2-compatible tool.
+
+The canonical address of an agent token is expressed as a Base58Check-encoded CIS-2 token address derived from the tuple ``(contract_index=10082, subindex=0, token_id)``. This address uniquely identifies the agent across tooling that understands Concordium CIS-2 addressing.
+
+On-chain agent state
+====================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 55
+
+   * - Field
+     - Type
+     - Description
+   * - ``token_id``
+     - u64
+     - Sequentially assigned on registration. Immutable.
+   * - ``owner``
+     - AccountAddress
+     - The Concordium account that currently owns the agent NFT. Changes on transfer.
+   * - ``agent_uri``
+     - string (optional)
+     - Public URL where the :doc:`Agent Card <agent-card>` JSON is hosted.
+   * - ``metadata_hash``
+     - bytes32 (optional)
+     - SHA-256 hash of the Agent Card bytes at ``agent_uri``. On-chain integrity anchor.
+   * - ``external_reference``
+     - ExternalReference (optional)
+     - A ``Cis8`` or ``Cis10`` reference linking the agent to an external key or platform handle. See below.
+   * - ``metadata``
+     - map<string, bytes>
+     - Arbitrary on-chain key-value store. The reserved key ``agentWallet`` holds the payment wallet address.
+   * - ``status``
+     - Active \| Revoked
+     - Registration status. Revoked agents remain queryable but are treated as inactive.
+
+External references
+===================
+
+An agent can carry one optional ``external_reference`` that links it to a cross-chain or cross-platform identity:
+
+- **Cis8 reference** — Points to a binding in the :doc:`CIS-8 External Key Registry <cis-8>`. Use this to attach an Ethereum, Solana, Cosmos, or Fetch.ai public key to the agent. The CIS-8 binding must exist before it can be set as a reference.
+- **Cis10 reference** — Points to a binding in the CIS-10 External Identifier Registry. Use this to attach a platform handle (Moltbook, X, GitHub, etc.) to the agent. Note that the CIS-10 contract integration is not yet active on the mainnet deployment.
+
+Native vs. external agent ownership
+=====================================
+
+Concordium uses Base58-encoded native accounts as the primary owner type for CIS-8004 agents. This is the default for any wallet or application operating natively on Concordium.
+
+For users and systems that operate primarily on Ethereum or another external chain, the recommended path is:
+
+1. **Create a Concordium account** to act as the on-chain owner. This is the account that signs the ``register`` transaction.
+2. **Register the external key with CIS-8** by calling ``build_cis8_canonical_bytes`` to derive the canonical bytes, signing them with the Ethereum private key, then submitting ``build_cis8_register`` from the Concordium account.
+3. **Register the agent in CIS-8004** with a ``Cis8`` external reference pointing at the CIS-8 binding. This permanently links the agent's NFT to the Ethereum address.
+
+Once the link exists, any tooling that knows the Ethereum address can resolve the Concordium account via the CIS-8 contract, then find the agent via the CIS-8004 external reference. The Agent Card's ``concordium`` extension block surfaces the ``token_address`` and contract references so that external registries can do this lookup without chain-specific knowledge.
+
+Contract entrypoints
+====================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Entrypoint
+     - Description
+   * - ``register``
+     - Mints a new agent NFT to the caller. Optional: ``agent_uri``, ``metadata_hash_hex``, ``external_reference``, and initial ``metadata`` key-value pairs.
+   * - ``revoke``
+     - Marks the agent as Revoked. Only the current owner or an approved operator can revoke.
+   * - ``setAgentURI``
+     - Updates ``agent_uri`` and/or ``metadata_hash`` for an existing agent. Caller must be the owner or an approved operator.
+   * - ``setMetadata``
+     - Sets one or more key-value pairs in the agent's on-chain metadata store.
+   * - ``setAgentWallet``
+     - Convenience entrypoint for the reserved ``agentWallet`` metadata key. Setting a new wallet address requires proof of control (EIP-712 for ETH wallets, or account ownership for native Concordium wallets).
+   * - ``transfer``
+     - Transfers ownership of the agent NFT to a new address. Transferring automatically clears the ``agentWallet`` metadata key.
+   * - ``updateOperator``
+     - Grants or revokes an operator's permission to manage the agent on the owner's behalf.
+   * - ``upgrade``
+     - Admin-only: upgrades the contract module. Does not affect stored agent data.
+   * - ``setExternalRegistries``
+     - Admin-only: updates the linked CIS-8 and CIS-10 contract addresses.
+
+Token address encoding
+======================
+
+The MCP tool ``token_address`` computes the Base58Check token address for a given ``(contract_index, subindex, token_id)`` triple. The complementary tool ``parse_token_address`` decodes a token address back into its component fields. These operations are purely off-chain and require no network round-trip.

--- a/source/mainnet/technical-reference/agent-registry/index.rst
+++ b/source/mainnet/technical-reference/agent-registry/index.rst
@@ -1,0 +1,73 @@
+.. include:: ../../variables.rst
+.. _agent-registry-reference:
+
+=============
+Agent Registry
+=============
+
+Reference documentation for the Concordium Agent Registry — a suite of on-chain contracts, standards, and supporting services that give AI agents a verified on-chain identity.
+
+.. grid:: 1 1 2 2
+   :gutter: 3
+
+   .. grid-item::
+
+      **Standards**
+
+      - :doc:`CIS-8: External Key Registry <cis-8>`
+      - :doc:`CIS-8004: Agent Registry <cis-8004>`
+
+      **Data formats**
+
+      - :doc:`Agent Card <agent-card>`
+
+   .. grid-item::
+
+      **Services**
+
+      - :doc:`MCP service <mcp-service>`
+      - :doc:`Indexer <indexer>`
+
+.. toctree::
+   :hidden:
+
+   CIS-8: External Key Registry <cis-8>
+   CIS-8004: Agent Registry <cis-8004>
+   Agent Card <agent-card>
+   MCP service <mcp-service>
+   Indexer <indexer>
+
+Overview
+========
+
+The Agent Registry gives every AI agent an on-chain identity anchor: discoverable, transferable, and — when combined with Concordium's ID layer — linked to a verified human owner.
+
+It is built from two complementary smart-contract standards:
+
+- **CIS-8004** is the core agent registry. Each registered agent is minted as a non-fungible CIS-2 token. The token stores a pointer to an off-chain :doc:`Agent Card <agent-card>` whose integrity is protected by an on-chain SHA-256 hash, plus an extensible key-value metadata store for on-chain properties such as the agent's payment wallet.
+
+- **CIS-8** is the cross-chain key registry. It records a cryptographically-proven binding between a Concordium native account and an external public key — an Ethereum address, a Solana key, or a key from any other supported chain. CIS-8 entries can be attached to CIS-8004 agents as an ``external_reference``, making agents equally accessible from within and outside the Concordium ecosystem.
+
+The :doc:`MCP service <mcp-service>` wraps these contracts in a Model Context Protocol server, exposing every registry operation as an AI-callable tool. The :doc:`Indexer <indexer>` processes on-chain events into a queryable REST API that powers agent discovery and search.
+
+Mainnet contract addresses
+==========================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 20 30
+
+   * - Contract
+     - Index
+     - Subindex
+     - Module reference
+   * - CIS-8004 Agent Registry
+     - 10082
+     - 0
+     - ``ba03e95330de2ad70cb8551d132bc7afe291b22068172a44e3a00dc09b63855f``
+   * - CIS-8 External Key Registry
+     - 10081
+     - 0
+     - ``08f71acbd16cdaca1e4184dbbc59b773ffc8f93c76fe2e56bfbd50bfcbee9d1d``
+
+Both contracts are visible on `CCDScan <https://ccdscan.io>`__.

--- a/source/mainnet/technical-reference/agent-registry/index.rst
+++ b/source/mainnet/technical-reference/agent-registry/index.rst
@@ -1,9 +1,9 @@
 .. include:: ../../variables.rst
 .. _agent-registry-reference:
 
-=============
+==============
 Agent Registry
-=============
+==============
 
 Reference documentation for the Concordium Agent Registry — a suite of on-chain contracts, standards, and supporting services that give AI agents a verified on-chain identity.
 

--- a/source/mainnet/technical-reference/agent-registry/indexer.rst
+++ b/source/mainnet/technical-reference/agent-registry/indexer.rst
@@ -1,0 +1,123 @@
+.. include:: ../../variables.rst
+.. _agent-registry-indexer:
+
+=======
+Indexer
+=======
+
+The Agent Registry Indexer is a service that subscribes to the Concordium chain, processes :doc:`CIS-8004 <cis-8004>` smart-contract events, and stores them in a queryable database. It exposes a REST API that powers the discovery and search tools in the :doc:`MCP service <mcp-service>`.
+
+The Indexer is **optional** for deployments that only need on-chain reads and transaction building. It is **required** for the following MCP tools:
+
+- ``list_agents``
+- ``search_agents``
+- ``recent_registrations``
+- ``recent_transfers``
+- ``agent_history``
+
+Without an Indexer, those tools return an error. All other tools read directly from the chain and work without it.
+
+Indexed events
+==============
+
+The Indexer processes the following CIS-8004 event types emitted by the Agent Registry contract:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Event
+     - Triggered by
+   * - ``Registered``
+     - A new agent NFT is minted via the ``register`` entrypoint.
+   * - ``Revoked``
+     - An agent is deactivated via the ``revoke`` entrypoint.
+   * - ``TokenMetadataChanged``
+     - ``agent_uri`` or ``metadata_hash`` is updated via ``setAgentURI``.
+   * - ``Transfer``
+     - The agent NFT is transferred to a new owner.
+   * - ``UpdateOperator``
+     - An operator is added or removed for an agent.
+
+Each indexed event records the block height, block hash, transaction hash, and the decoded event payload.
+
+Running the Indexer
+===================
+
+Prerequisites
+-------------
+
+- Docker (recommended) or a compatible Rust runtime.
+- A reachable Concordium gRPC v2 endpoint for the target network.
+- A PostgreSQL database (version 14 or later).
+
+Configuration
+-------------
+
+The Indexer reads configuration from environment variables:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Variable
+     - Description
+   * - ``INDEXER_NETWORK``
+     - Target network. One of ``mainnet``, ``testnet``, ``devnet``.
+   * - ``INDEXER_GRPC_ENDPOINT``
+     - gRPC v2 endpoint of a Concordium node. Default: public endpoint for the configured network.
+   * - ``INDEXER_CONTRACT_INDEX``
+     - Index of the CIS-8004 contract to watch. Default: ``10082`` (mainnet).
+   * - ``INDEXER_CONTRACT_SUBINDEX``
+     - Subindex of the CIS-8004 contract. Default: ``0``.
+   * - ``INDEXER_DATABASE_URL``
+     - PostgreSQL connection string (e.g. ``postgres://user:pass@localhost:5432/agent_registry``).
+   * - ``INDEXER_PORT``
+     - Port for the REST API. Default: ``4400``.
+   * - ``INDEXER_START_HEIGHT``
+     - Optional block height to start indexing from. Omit to start from the contract's deployment block.
+
+Docker quick-start
+------------------
+
+.. code-block:: bash
+
+   docker run -e INDEXER_NETWORK=mainnet \
+              -e INDEXER_DATABASE_URL=postgres://user:pass@host.docker.internal:5432/agent_registry \
+              -p 4400:4400 \
+              concordium/agent-registry-indexer:latest
+
+The Indexer begins streaming events from the chain on startup and catches up from the last indexed block on restart. It exposes the REST API on port ``4400`` once the initial sync is complete.
+
+REST API
+========
+
+The Indexer exposes a lightweight REST API consumed by the MCP service. The base URL is configurable; the default for local deployments is ``http://localhost:4400``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Endpoint
+     - Description
+   * - ``GET /agents``
+     - List agents with optional ``status``, ``owner``, ``limit``, and ``offset`` query parameters.
+   * - ``GET /agents/search?q=<term>``
+     - Substring search across ``agent_uri`` and token ID text.
+   * - ``GET /agents/:token_id``
+     - Full record for a single agent by token ID.
+   * - ``GET /agents/:token_id/history``
+     - Chronological list of all indexed events for an agent.
+   * - ``GET /events/registrations``
+     - Recent ``Registered`` events. Supports ``limit`` and ``since_block`` query parameters.
+   * - ``GET /events/transfers``
+     - Recent ``Transfer`` events. Supports ``limit`` query parameter.
+   * - ``GET /health``
+     - Returns the Indexer's current block height and lag behind the chain tip.
+
+Sync state
+==========
+
+The Indexer maintains a cursor of the last successfully processed block. On restart, it resumes from that cursor rather than re-indexing from the beginning. The ``network_status`` MCP tool surfaces the Indexer's current block height and its lag (in blocks) behind the chain's latest finalised block.
+
+A lag of a few blocks is normal; a growing lag indicates the Indexer cannot keep up with the chain and may need more resources or a faster database connection.

--- a/source/mainnet/technical-reference/agent-registry/mcp-service.rst
+++ b/source/mainnet/technical-reference/agent-registry/mcp-service.rst
@@ -1,0 +1,207 @@
+.. include:: ../../variables.rst
+.. _agent-registry-mcp:
+
+===========
+MCP service
+===========
+
+The Agent Registry MCP service is a `Model Context Protocol <https://modelcontextprotocol.io/>`__ server that exposes every Agent Registry operation as an AI-callable tool. It lets AI development tools — including Claude, GPT, LangChain, and Cursor — read from and write to the :doc:`CIS-8004 <cis-8004>` and :doc:`CIS-8 <cis-8>` contracts without requiring the AI to understand Concordium's wire formats or cryptography.
+
+The service holds **no private keys**. All tools that produce transactions return a sign-ready payload (hex-encoded parameter bytes plus metadata) that the caller's wallet must sign and submit. The MCP service is stateless with respect to user credentials.
+
+Hosted service
+==============
+
+A hosted instance of the MCP service is available for direct use in AI assistants and agent frameworks. Connect your MCP-compatible client to the hosted endpoint to gain immediate access to all registry tools on mainnet, testnet, and devnet.
+
+Contact the Concordium team or check the `Concordium developer portal <https://developer.concordium.software>`__ for the current hosted endpoint URL and connection instructions.
+
+Running locally
+===============
+
+For production deployments, custom network configurations, or offline use, you can run the MCP service locally alongside your own :doc:`Indexer <indexer>` instance.
+
+Prerequisites
+-------------
+
+- Docker (recommended) or a Node.js runtime.
+- A reachable Concordium gRPC v2 endpoint for the target network.
+- A running :doc:`Indexer <indexer>` instance if you need discovery and search tools (``list_agents``, ``search_agents``, ``recent_registrations``).
+
+Configuration
+-------------
+
+The service reads configuration from environment variables:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Variable
+     - Description
+   * - ``MCP_NETWORK``
+     - Target network. One of ``mainnet``, ``testnet``, ``devnet``. Defaults to ``devnet``.
+   * - ``MCP_GRPC_ENDPOINT``
+     - gRPC v2 endpoint of a Concordium node. Defaults to the public endpoint for the configured network.
+   * - ``MCP_INDEXER_URL``
+     - Base URL of the Agent Registry Indexer REST API (e.g. ``http://localhost:4400``). Required for discovery tools; optional for read/write-only deployments.
+   * - ``MCP_CIS8004_CONTRACT``
+     - Override the CIS-8004 contract address in ``index,subindex`` format (e.g. ``10082,0``). Use only when pointing at a custom deployment.
+   * - ``MCP_CIS8_CONTRACT``
+     - Override the CIS-8 contract address. Same format as above.
+
+Docker quick-start
+------------------
+
+.. code-block:: bash
+
+   docker run -e MCP_NETWORK=mainnet \
+              -e MCP_INDEXER_URL=http://host.docker.internal:4400 \
+              -p 3000:3000 \
+              concordium/agent-registry-mcp:latest
+
+The server listens on port ``3000`` by default and exposes a standard MCP endpoint at ``/mcp``.
+
+Available tools
+===============
+
+The MCP service exposes 35 tools, grouped by function.
+
+Discovery and search (require Indexer)
+--------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Tool
+     - Description
+   * - ``list_agents``
+     - Lists all registered agents. Supports pagination, owner filter, and status filter (Active / Revoked).
+   * - ``search_agents``
+     - Substring search across ``agent_uri`` and token ID text.
+   * - ``recent_registrations``
+     - Returns the most recent ``Registered`` events, newest first. Optionally filter by block height.
+   * - ``recent_transfers``
+     - Returns the most recent ``Transfer`` events for agent NFTs.
+   * - ``agent_history``
+     - Full event history for a single agent token.
+
+On-chain lookups (no Indexer required)
+---------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Tool
+     - Description
+   * - ``agent_by_token_address``
+     - Resolves a Base58Check token address to a full agent record.
+   * - ``agent_by_external_reference``
+     - Resolves a ``Cis8`` (external key) or ``Cis10`` (platform handle) reference to an agent.
+   * - ``agents_by_owner``
+     - Returns all agents owned by a given Concordium account.
+   * - ``agent_of``
+     - Returns the agent associated with a given account, if any.
+   * - ``get_metadata``
+     - Reads a single on-chain metadata key for an agent. Returns value as hex and UTF-8 text.
+   * - ``get_agent_wallet``
+     - Returns the payment wallet address stored in the reserved ``agentWallet`` metadata key.
+   * - ``is_active``
+     - Returns true if the agent's status is Active, false if Revoked or not found.
+   * - ``owner_of_key``
+     - Returns the Concordium account that registered a given CIS-8 external key, or null.
+
+Transaction builders (CIS-8004)
+---------------------------------
+
+All builder tools return ``{ hex, schema_json }`` — the hex is the wire-encoded parameter, ready for signing. No private keys are required or accepted.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Tool
+     - Description
+   * - ``build_register``
+     - Builds a ``register`` payload to mint a new agent NFT.
+   * - ``build_revoke``
+     - Builds a ``revoke`` payload to deactivate an agent.
+   * - ``build_set_agent_uri``
+     - Builds a ``setAgentURI`` payload to update ``agent_uri`` and/or ``metadata_hash``.
+   * - ``build_set_metadata``
+     - Builds a ``setMetadata`` payload for one or more key-value pairs.
+   * - ``build_set_agent_wallet``
+     - Builds a ``setAgentWallet`` payload to update the payment wallet.
+   * - ``build_transfer``
+     - Builds a CIS-2 ``transfer`` payload to transfer the agent NFT.
+   * - ``build_transfer_admin``
+     - Admin-only: builds a forced transfer payload.
+   * - ``build_update_operator``
+     - Builds an ``updateOperator`` payload to grant or revoke an operator.
+   * - ``build_upgrade``
+     - Admin-only: builds a module upgrade payload.
+   * - ``build_set_external_registries``
+     - Admin-only: updates the linked CIS-8 and CIS-10 contract addresses atomically.
+
+Transaction builders (CIS-8)
+------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Tool
+     - Description
+   * - ``build_cis8_canonical_bytes``
+     - Returns the exact bytes the external key must sign before calling ``build_cis8_register``. Pure off-chain computation.
+   * - ``build_cis8_register``
+     - Builds a CIS-8 ``register`` payload to record a new cross-chain key binding.
+   * - ``build_cis8_revoke``
+     - Builds a CIS-8 ``revoke`` payload to remove a key binding.
+   * - ``build_cis8_update_metadata``
+     - Builds a CIS-8 ``updateMetadata`` payload.
+   * - ``set_agent_wallet_canonical_bytes``
+     - Returns the canonical bytes required to prove control of a wallet when setting ``agentWallet``.
+
+Utilities
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Tool
+     - Description
+   * - ``build_agent_card``
+     - Generates a complete, valid Agent Card JSON and its SHA-256 hash from human-readable inputs.
+   * - ``verify_agent_card``
+     - Fetches ``agent_uri`` and verifies its hash against the on-chain ``metadata_hash``.
+   * - ``token_address``
+     - Computes the Base58Check CIS-2 token address for a ``(contract_index, subindex, token_id)`` triple. Off-chain only.
+   * - ``parse_token_address``
+     - Decodes a Base58Check token address into its component fields. Off-chain only.
+   * - ``agent_registry_capabilities``
+     - Lists available tools, unavailable tools with reasons, and the configured backends for a given network.
+   * - ``network_status``
+     - Returns the gRPC endpoint, latest finalised block, and Indexer sync state for a network.
+   * - ``contract_info``
+     - Returns contract addresses, module references, and admin accounts for both CIS-8004 and CIS-8 on a given network.
+
+Connecting Claude Desktop
+=========================
+
+Add the following block to your Claude Desktop MCP configuration (``claude_desktop_config.json``) to connect to the hosted service:
+
+.. code-block:: json
+
+   {
+     "mcpServers": {
+       "concordium-agent-registry": {
+         "url": "<hosted-mcp-endpoint>"
+       }
+     }
+   }
+
+For a locally running server, replace the URL with ``http://localhost:3000/mcp``.

--- a/source/mainnet/technical-reference/index.rst
+++ b/source/mainnet/technical-reference/index.rst
@@ -52,6 +52,14 @@ Reference documentation for Concordium APIs, SDKs, command-line tools, smart con
 
    .. grid-item::
 
+      **Agent Registry**
+
+      - :doc:`CIS-8: External Key Registry <agent-registry/cis-8>`
+      - :doc:`CIS-8004: Agent Registry <agent-registry/cis-8004>`
+      - :doc:`Agent Card <agent-registry/agent-card>`
+      - :doc:`MCP service <agent-registry/mcp-service>`
+      - :doc:`Indexer <agent-registry/indexer>`
+
       **Identity**
 
       - :doc:`ID attributes <id-attributes-reference>`
@@ -109,6 +117,17 @@ Reference documentation for Concordium APIs, SDKs, command-line tools, smart con
    Auxiliary Tools <auxiliary-tools>
    Election Coordinator <coordinator>
    Glossary <glossary>
+
+.. toctree::
+   :caption: Agent Registry
+   :hidden:
+
+   Agent Registry <agent-registry/index>
+   CIS-8: External Key Registry <agent-registry/cis-8>
+   CIS-8004: Agent Registry <agent-registry/cis-8004>
+   Agent Card <agent-registry/agent-card>
+   MCP service <agent-registry/mcp-service>
+   Indexer <agent-registry/indexer>
 
 .. toctree::
    :caption: Identity


### PR DESCRIPTION
## Summary

Adds a new **Agent Registry** section to the Technical Reference and a companion How-to guide.

**New pages — Technical Reference:**
- CIS-8: External Key Registry — cross-chain key bindings, proof schemes (Ethereum, Solana, Cosmos, Fetch.ai), registration workflow
- CIS-8004: Agent Registry — token model, on-chain state, entrypoints, native vs ETH ownership, external references
- Agent Card — full field spec, Concordium extension block, example JSON, build/host/verify workflow
- MCP service — hosted and local setup, all 35 tools grouped by function, Docker quick-start, Claude Desktop config
- Indexer — indexed events, env vars, Docker quick-start, REST API reference, sync state

**New page — How-to / Integrations:**
- Use the Agent Registry — native vs ETH concept, Agent Card explanation, step-by-step registration for both flows, update and transfer

**Updated:**
- `technical-reference/index.rst` — new Agent Registry section in grid + toctree
- `how-to/index.rst` — Use the Agent Registry added to Integrations
- `public/llms.txt` — new Agent Registry section with all six pages

## Before publishing

- Fill in the real Docker image names in `mcp-service.rst` (`concordium/agent-registry-mcp` and `concordium/agent-registry-indexer` are placeholders)
- Add the hosted MCP endpoint URL in `mcp-service.rst`
- Confirm the indexer Docker image name in `indexer.rst`

## Test plan

- [ ] `pipenv run make dev-mainnet` builds cleanly with no warnings
- [ ] All new pages appear in the sidebar under Reference > Agent Registry
- [ ] Use the Agent Registry appears under How-to > Integrations
- [ ] Cross-reference links (`:ref:` targets) resolve correctly
- [ ] llms.txt entries point to correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
