### PR TITLE
Update the firmware version for nanosp

### DIFF
--- a/source/mainnet/how-to/governance/install-ledger-app.rst
+++ b/source/mainnet/how-to/governance/install-ledger-app.rst
@@ -1,7 +1,7 @@
 .. include:: ../../variables.rst
 
 .. |nano-s-firmware| replace:: **2.1.0**
-.. |nano-s-plus-firmware| replace:: **1.5.1**
+.. |nano-s-plus-firmware| replace:: **1.6.1**
 .. |ccd-governance-version| replace:: **1.3.0**
 .. _dl-nanos: https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.3.0/concordium-governance-ledger-app-1.3.0-nanos-2.1.0.zip
 .. _dl-nanosp: https://github.com/Concordium/concordium-ledger-app/releases/download/governance-app%2F1.3.0/concordium-governance-ledger-app-1.3.0-nanosplus.zip


### PR DESCRIPTION
Matches the latest firmware version for nanosp, and the updated release at https://github.com/Concordium/concordium-ledger-app/releases/tag/governance-app%2F1.3.0