### PR TITLE
Badge: key verifyUrl on tokenAddressBase58, not the account

### DIFF
--- a/source/mainnet/technical-reference/agent-registry/concordium-badge.rst
+++ b/source/mainnet/technical-reference/agent-registry/concordium-badge.rst
@@ -85,7 +85,7 @@ Add a ``concordium`` block to the :doc:`Agent Card <agent-card>`:
      "verify": "Resolve tokenAddress via CIS-8004 agent_of; confirm owner + status=Active + card SHA-256 == metadata_hash.",
      "verification": {
        "service": "Concordium Agent Registry",
-       "verifyUrl": "https://agent-registry-mcp.concordium.com/v1/badge-check/<account>",
+       "verifyUrl": "https://agent-registry-mcp.concordium.com/v1/badge-check/<tokenAddressBase58>",
        "mcp": "https://agent-registry-mcp.concordium.com/mcp",
        "docs": "https://docs.concordium.com/en/mainnet/technical-reference/agent-registry/concordium-badge.html"
      }
@@ -102,7 +102,7 @@ The ``verify`` string names the steps; the optional ``verification`` block names
    * - ``service``
      - Human-readable name of the resolver / registry service.
    * - ``verifyUrl``
-     - REST endpoint — the owner account's badge check — returning a JSON verdict for each of the account's badges, including this one (owner, ``status``, and card-hash match). One ``GET``, no MCP client, SDK, or node access required.
+     - REST endpoint keyed on the badge itself (``tokenAddressBase58``) — a single ``GET`` returns the JSON verdict for **this** badge (owner, ``status``, and card-hash match). No MCP client, SDK, or node access required.
    * - ``mcp``
      - MCP endpoint for agents that speak the Model Context Protocol; they can call ``verify_agent_card`` / ``agent_by_token_address`` directly.
    * - ``docs``


### PR DESCRIPTION
## What

Fixes the `verification.verifyUrl` example in the Concordium Badge to key on the badge's **`tokenAddressBase58`**, not the owner `account`:

```diff
- "verifyUrl": "…/v1/badge-check/<account>",
+ "verifyUrl": "…/v1/badge-check/<tokenAddressBase58>",
```

## Why

A verifier reading a card holds **the badge itself** — the token address is right there in the `concordium` block. Keying `verifyUrl` on the account made it (a) require pulling `owner.account` out first, and (b) return a *list* of the account's badges rather than a verdict for **this** one. Keying on the token address means one `GET` → one verdict for the exact badge in hand, which is the whole point of a self-resolving badge.

The hosted resolver's `/v1/badge-check/:id` accepts **either** form (account → all its badges; token address → that one badge), told apart by the base58 version byte, so nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
