### PR TITLE
Remove the double linking to agent registry pages

### DIFF
--- a/source/mainnet/technical-reference/agent-registry/index.rst
+++ b/source/mainnet/technical-reference/agent-registry/index.rst
@@ -29,16 +29,6 @@ Reference documentation for the Concordium Agent Registry — a suite of on-chai
       - :doc:`MCP service <mcp-service>`
       - :doc:`Indexer <indexer>`
 
-.. toctree::
-   :hidden:
-
-   CIS-8: External Key Registry <cis-8>
-   CIS-8004: Agent Registry <cis-8004>
-   Agent Card <agent-card>
-   Concordium Badge <concordium-badge>
-   MCP service <mcp-service>
-   Indexer <indexer>
-
 Overview
 ========
 


### PR DESCRIPTION
## Purpose

The agent registry pages are shown twice in the side navigation, this PR is a fix

<img width="653" height="718" alt="Screenshot 2026-08-07 at 13 53 22" src="https://github.com/user-attachments/assets/f7211ba9-0769-429d-ae7c-dd85457a212e" />

---------

Now it becomes:

<img width="653" height="718" alt="Screenshot 2026-08-07 at 13 55 23" src="https://github.com/user-attachments/assets/e723d15c-bbce-4f76-9ab6-641fd4c85026" />

